### PR TITLE
Enable flake8 linting via pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ jobs:
             - ./venv
           key: v1-dependencies-{{ checksum ".circleci/requirements.txt" }}
 
+      - run:
+          name: run linting
+          command: |
+            . venv/bin/activate
+            tox -e lint
+
       # run tests!
       - run:
           name: run tests
@@ -49,4 +55,3 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: test-reports
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+-   repo: https://github.com/python/black
+    rev: 19.3b0
+    hooks:
+    -   id: black
+        args: [--safe]
+        language_version: python3
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: flake8
+        language_version: python3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,4 +29,3 @@
 - 0.4:   Unicode support, Python3 support, ``rst`` tables.
 - 0.3:   Initial PyPI release. Table formats: ``simple``, ``plain``,
   ``grid``, ``pipe``, and ``orgtbl``.
-

--- a/README.md
+++ b/README.md
@@ -715,4 +715,3 @@ Maier, Andy MacKinlay, Thomas Roten, Jue Wang, Joe King, Samuel Phan,
 Nick Satterly, Daniel Robbins, Dmitry B, Lars Butler, Andreas Maier,
 Dick Marinus, Sébastien Celles, Yago González, Andrew Gaul, Wim Glenn,
 Jean Michel Rouly, Tim Gates, John Vandenberg.
-

--- a/benchmark.py
+++ b/benchmark.py
@@ -74,37 +74,44 @@ def run_tabulate(table, widechars=False):
 
 """
 
-methods = [(u"join with tabs and newlines", "join_table(table)"),
-           (u"csv to StringIO", "csv_table(table)"),
-           (u"asciitable (%s)" % asciitable.__version__, "run_asciitable(table)"),
-           (u"tabulate (%s)" % tabulate.__version__, "run_tabulate(table)"),
-           (u"tabulate (%s, WIDE_CHARS_MODE)" % tabulate.__version__, "run_tabulate(table, widechars=True)"),
-           (u"PrettyTable (%s)" % prettytable.__version__, "run_prettytable(table)"),
-           (u"texttable (%s)" % texttable.__version__, "run_texttable(table)"),
-           ]
+methods = [
+    ("join with tabs and newlines", "join_table(table)"),
+    ("csv to StringIO", "csv_table(table)"),
+    ("asciitable (%s)" % asciitable.__version__, "run_asciitable(table)"),
+    ("tabulate (%s)" % tabulate.__version__, "run_tabulate(table)"),
+    (
+        "tabulate (%s, WIDE_CHARS_MODE)" % tabulate.__version__,
+        "run_tabulate(table, widechars=True)",
+    ),
+    ("PrettyTable (%s)" % prettytable.__version__, "run_prettytable(table)"),
+    ("texttable (%s)" % texttable.__version__, "run_texttable(table)"),
+]
 
 
 if tabulate.wcwidth is None:
-    del(methods[4])
+    del methods[4]
 
 
 def benchmark(n):
     global methods
-    if '--onlyself' in sys.argv[1:]:
-        methods = [ m for m in methods if m[0].startswith("tabulate") ]
+    if "--onlyself" in sys.argv[1:]:
+        methods = [m for m in methods if m[0].startswith("tabulate")]
     else:
         methods = methods
 
-    results = [(desc, timeit(code, setup_code, number=n)/n * 1e6)
-               for desc, code in methods]
+    results = [
+        (desc, timeit(code, setup_code, number=n) / n * 1e6) for desc, code in methods
+    ]
     mintime = min(map(lambda x: x[1], results))
-    results = [(desc, t, t/mintime) for desc, t in
-               sorted(results, key=lambda x: x[1])]
-    table = tabulate.tabulate(results,
-                              [u"Table formatter", u"time, μs", u"rel. time"],
-                              u"rst", floatfmt=".1f")
+    results = [
+        (desc, t, t / mintime) for desc, t in sorted(results, key=lambda x: x[1])
+    ]
+    table = tabulate.tabulate(
+        results, ["Table formatter", "time, μs", "rel. time"], "rst", floatfmt=".1f"
+    )
 
     import platform
+
     if platform.platform().startswith("Windows"):
         print(table)
     elif python_version_tuple()[0] < "3":

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,14 @@ import os
 import re
 
 # strip links from the descripton on the PyPI
-if python_version_tuple()[0] >= '3':
+if python_version_tuple()[0] >= "3":
     LONG_DESCRIPTION = open("README.md", "r", encoding="utf-8").read()
 else:
     LONG_DESCRIPTION = open("README.md", "r").read()
 
 # strip Build Status from the PyPI package
 try:
-    if python_version_tuple()[:2] >= ('2', '7'):
+    if python_version_tuple()[:2] >= ("2", "7"):
         status_re = "^Build status\n(.*\n){7}"
         LONG_DESCRIPTION = re.sub(status_re, "", LONG_DESCRIPTION, flags=re.M)
 except TypeError:
@@ -28,35 +28,39 @@ except TypeError:
     else:
         raise
 
-install_options = os.environ.get("TABULATE_INSTALL","").split(",")
+install_options = os.environ.get("TABULATE_INSTALL", "").split(",")
 libonly_flags = set(["lib-only", "libonly", "no-cli", "without-cli"])
 if libonly_flags.intersection(install_options):
     console_scripts = []
 else:
-    console_scripts = ['tabulate = tabulate:_main']
+    console_scripts = ["tabulate = tabulate:_main"]
 
 
-setup(name='tabulate',
-      version='0.8.6',
-      description='Pretty-print tabular data',
-      long_description=LONG_DESCRIPTION,
-      long_description_content_type="text/markdown",
-      author='Sergey Astanin',
-      author_email='s.astanin@gmail.com',
-      url='https://github.com/astanin/python-tabulate',
-      license='MIT',
-      classifiers= [ "Development Status :: 4 - Beta",
-                     "License :: OSI Approved :: MIT License",
-                     "Operating System :: OS Independent",
-                     "Programming Language :: Python :: 2",
-                     "Programming Language :: Python :: 2.7",
-                     "Programming Language :: Python :: 3.3",
-                     "Programming Language :: Python :: 3.4",
-                     "Programming Language :: Python :: 3",
-                     "Programming Language :: Python :: 3.5",
-                     "Programming Language :: Python :: 3.6",
-                     "Topic :: Software Development :: Libraries" ],
-      py_modules = ['tabulate'],
-      entry_points = {'console_scripts': console_scripts},
-      extras_require = {'widechars': ['wcwidth']},
-      test_suite = 'nose.collector')
+setup(
+    name="tabulate",
+    version="0.8.6",
+    description="Pretty-print tabular data",
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
+    author="Sergey Astanin",
+    author_email="s.astanin@gmail.com",
+    url="https://github.com/astanin/python-tabulate",
+    license="MIT",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Software Development :: Libraries",
+    ],
+    py_modules=["tabulate"],
+    entry_points={"console_scripts": console_scripts},
+    extras_require={"widechars": ["wcwidth"]},
+    test_suite="nose.collector",
+)

--- a/tabulate.py
+++ b/tabulate.py
@@ -18,20 +18,23 @@ else:
 if python_version_tuple()[0] < "3":
     from itertools import izip_longest
     from functools import partial
+
     _none_type = type(None)
     _bool_type = bool
     _int_type = int
-    _long_type = long
+    _long_type = long  # noqa
     _float_type = float
-    _text_type = unicode
+    _text_type = unicode  # noqa
     _binary_type = str
 
     def _is_file(f):
-        return isinstance(f, file)
+        return hasattr(f, "read")
+
 
 else:
     from itertools import zip_longest as izip_longest
     from functools import reduce, partial
+
     _none_type = type(None)
     _bool_type = bool
     _int_type = int
@@ -42,8 +45,10 @@ else:
     basestring = str
 
     import io
+
     def _is_file(f):
         return isinstance(f, io.IOBase)
+
 
 try:
     import wcwidth  # optional wide-character (CJK) support
@@ -61,8 +66,8 @@ MIN_PADDING = 2
 # Whether or not to preserve leading/trailing whitespace in data.
 PRESERVE_WHITESPACE = False
 
-_DEFAULT_FLOATFMT="g"
-_DEFAULT_MISSINGVAL=""
+_DEFAULT_FLOATFMT = "g"
+_DEFAULT_MISSINGVAL = ""
 
 
 # if True, enable wide-character (CJK) support
@@ -106,10 +111,19 @@ DataRow = namedtuple("DataRow", ["begin", "sep", "end"])
 #   - either None, to display all table elements unconditionally,
 #   - or a list of elements not to be displayed if the table has column headers.
 #
-TableFormat = namedtuple("TableFormat", ["lineabove", "linebelowheader",
-                                         "linebetweenrows", "linebelow",
-                                         "headerrow", "datarow",
-                                         "padding", "with_header_hide"])
+TableFormat = namedtuple(
+    "TableFormat",
+    [
+        "lineabove",
+        "linebelowheader",
+        "linebetweenrows",
+        "linebelow",
+        "headerrow",
+        "datarow",
+        "padding",
+        "with_header_hide",
+    ],
+)
 
 
 def _pipe_segment_with_colons(align, colwidth):
@@ -117,13 +131,13 @@ def _pipe_segment_with_colons(align, colwidth):
     indicate column's alignment (as in `pipe` output format)."""
     w = colwidth
     if align in ["right", "decimal"]:
-        return ('-' * (w - 1)) + ":"
+        return ("-" * (w - 1)) + ":"
     elif align == "center":
-        return ":" + ('-' * (w - 2)) + ":"
+        return ":" + ("-" * (w - 2)) + ":"
     elif align == "left":
-        return ":" + ('-' * (w - 1))
+        return ":" + ("-" * (w - 1))
     else:
-        return '-' * w
+        return "-" * w
 
 
 def _pipe_line_with_colons(colwidths, colaligns):
@@ -134,23 +148,26 @@ def _pipe_line_with_colons(colwidths, colaligns):
 
 
 def _mediawiki_row_with_attrs(separator, cell_values, colwidths, colaligns):
-    alignment = { "left":    '',
-                  "right":   'align="right"| ',
-                  "center":  'align="center"| ',
-                  "decimal": 'align="right"| ' }
+    alignment = {
+        "left": "",
+        "right": 'align="right"| ',
+        "center": 'align="center"| ',
+        "decimal": 'align="right"| ',
+    }
     # hard-coded padding _around_ align attribute and value together
     # rather than padding parameter which affects only the value
-    values_with_attrs = [' ' + alignment.get(a, '') + c + ' '
-                         for c, a in zip(cell_values, colaligns)]
-    colsep = separator*2
+    values_with_attrs = [
+        " " + alignment.get(a, "") + c + " " for c, a in zip(cell_values, colaligns)
+    ]
+    colsep = separator * 2
     return (separator + colsep.join(values_with_attrs)).rstrip()
 
 
 def _textile_row_with_attrs(cell_values, colwidths, colaligns):
-    cell_values[0] += ' '
-    alignment = { "left": "<.", "right": ">.", "center": "=.", "decimal": ">." }
-    values = (alignment.get(a, '') + v for a, v in zip(colaligns, cell_values))
-    return '|' + '|'.join(values) + '|'
+    cell_values[0] += " "
+    alignment = {"left": "<.", "right": ">.", "center": "=.", "decimal": ">."}
+    values = (alignment.get(a, "") + v for a, v in zip(colaligns, cell_values))
+    return "|" + "|".join(values) + "|"
 
 
 def _html_begin_table_without_header(colwidths_ignore, colaligns_ignore):
@@ -159,49 +176,71 @@ def _html_begin_table_without_header(colwidths_ignore, colaligns_ignore):
 
 
 def _html_row_with_attrs(celltag, cell_values, colwidths, colaligns):
-    alignment = { "left":    '',
-                  "right":   ' style="text-align: right;"',
-                  "center":  ' style="text-align: center;"',
-                  "decimal": ' style="text-align: right;"' }
-    values_with_attrs = ["<{0}{1}>{2}</{0}>".format(celltag, alignment.get(a, ''), c)
-                         for c, a in zip(cell_values, colaligns)]
+    alignment = {
+        "left": "",
+        "right": ' style="text-align: right;"',
+        "center": ' style="text-align: center;"',
+        "decimal": ' style="text-align: right;"',
+    }
+    values_with_attrs = [
+        "<{0}{1}>{2}</{0}>".format(celltag, alignment.get(a, ""), c)
+        for c, a in zip(cell_values, colaligns)
+    ]
     rowhtml = "<tr>" + "".join(values_with_attrs).rstrip() + "</tr>"
     if celltag == "th":  # it's a header row, create a new table header
-        rowhtml = "\n".join(["<table>",
-                             "<thead>",
-                             rowhtml,
-                             "</thead>",
-                             "<tbody>"])
+        rowhtml = "\n".join(["<table>", "<thead>", rowhtml, "</thead>", "<tbody>"])
     return rowhtml
 
-def _moin_row_with_attrs(celltag, cell_values, colwidths, colaligns, header=''):
-    alignment = { "left":    '',
-                  "right":   '<style="text-align: right;">',
-                  "center":  '<style="text-align: center;">',
-                  "decimal": '<style="text-align: right;">' }
-    values_with_attrs = ["{0}{1} {2} ".format(celltag,
-                                              alignment.get(a, ''),
-                                              header+c+header)
-                         for c, a in zip(cell_values, colaligns)]
-    return "".join(values_with_attrs)+"||"
+
+def _moin_row_with_attrs(celltag, cell_values, colwidths, colaligns, header=""):
+    alignment = {
+        "left": "",
+        "right": '<style="text-align: right;">',
+        "center": '<style="text-align: center;">',
+        "decimal": '<style="text-align: right;">',
+    }
+    values_with_attrs = [
+        "{0}{1} {2} ".format(celltag, alignment.get(a, ""), header + c + header)
+        for c, a in zip(cell_values, colaligns)
+    ]
+    return "".join(values_with_attrs) + "||"
+
 
 def _latex_line_begin_tabular(colwidths, colaligns, booktabs=False):
-    alignment = { "left": "l", "right": "r", "center": "c", "decimal": "r" }
+    alignment = {"left": "l", "right": "r", "center": "c", "decimal": "r"}
     tabular_columns_fmt = "".join([alignment.get(a, "l") for a in colaligns])
-    return "\n".join(["\\begin{tabular}{" + tabular_columns_fmt + "}",
-                      "\\toprule" if booktabs else "\\hline"])
+    return "\n".join(
+        [
+            "\\begin{tabular}{" + tabular_columns_fmt + "}",
+            "\\toprule" if booktabs else "\\hline",
+        ]
+    )
 
-LATEX_ESCAPE_RULES = {r"&": r"\&", r"%": r"\%", r"$": r"\$", r"#": r"\#",
-                      r"_": r"\_", r"^": r"\^{}", r"{": r"\{", r"}": r"\}",
-                      r"~": r"\textasciitilde{}", "\\": r"\textbackslash{}",
-                      r"<": r"\ensuremath{<}", r">": r"\ensuremath{>}"}
+
+LATEX_ESCAPE_RULES = {
+    r"&": r"\&",
+    r"%": r"\%",
+    r"$": r"\$",
+    r"#": r"\#",
+    r"_": r"\_",
+    r"^": r"\^{}",
+    r"{": r"\{",
+    r"}": r"\}",
+    r"~": r"\textasciitilde{}",
+    "\\": r"\textbackslash{}",
+    r"<": r"\ensuremath{<}",
+    r">": r"\ensuremath{>}",
+}
+
 
 def _latex_row(cell_values, colwidths, colaligns, escrules=LATEX_ESCAPE_RULES):
     def escape_char(c):
         return escrules.get(c, c)
+
     escaped_values = ["".join(map(escape_char, cell)) for cell in cell_values]
     rowfmt = DataRow("", "&", "\\\\")
     return _build_simple_row(escaped_values, rowfmt)
+
 
 def _rst_escape_first_column(rows, headers):
     def escape_empty(val):
@@ -209,6 +248,7 @@ def _rst_escape_first_column(rows, headers):
             return ".."
         else:
             return val
+
     new_headers = list(headers)
     new_rows = []
     if headers:
@@ -221,164 +261,213 @@ def _rst_escape_first_column(rows, headers):
     return new_rows, new_headers
 
 
-_table_formats = {"simple":
-                  TableFormat(lineabove=Line("", "-", "  ", ""),
-                              linebelowheader=Line("", "-", "  ", ""),
-                              linebetweenrows=None,
-                              linebelow=Line("", "-", "  ", ""),
-                              headerrow=DataRow("", "  ", ""),
-                              datarow=DataRow("", "  ", ""),
-                              padding=0,
-                              with_header_hide=["lineabove", "linebelow"]),
-                  "plain":
-                  TableFormat(lineabove=None, linebelowheader=None,
-                              linebetweenrows=None, linebelow=None,
-                              headerrow=DataRow("", "  ", ""),
-                              datarow=DataRow("", "  ", ""),
-                              padding=0, with_header_hide=None),
-                  "grid":
-                  TableFormat(lineabove=Line("+", "-", "+", "+"),
-                              linebelowheader=Line("+", "=", "+", "+"),
-                              linebetweenrows=Line("+", "-", "+", "+"),
-                              linebelow=Line("+", "-", "+", "+"),
-                              headerrow=DataRow("|", "|", "|"),
-                              datarow=DataRow("|", "|", "|"),
-                              padding=1, with_header_hide=None),
-                  "fancy_grid":
-                  TableFormat(lineabove=Line("╒", "═", "╤", "╕"),
-                              linebelowheader=Line("╞", "═", "╪", "╡"),
-                              linebetweenrows=Line("├", "─", "┼", "┤"),
-                              linebelow=Line("╘", "═", "╧", "╛"),
-                              headerrow=DataRow("│", "│", "│"),
-                              datarow=DataRow("│", "│", "│"),
-                              padding=1, with_header_hide=None),
-                  "github":
-                  TableFormat(lineabove=Line("|", "-", "|", "|"),
-                              linebelowheader=Line("|", "-", "|", "|"),
-                              linebetweenrows=None,
-                              linebelow=None,
-                              headerrow=DataRow("|", "|", "|"),
-                              datarow=DataRow("|", "|", "|"),
-                              padding=1,
-                              with_header_hide=["lineabove"]),
-                  "pipe":
-                  TableFormat(lineabove=_pipe_line_with_colons,
-                              linebelowheader=_pipe_line_with_colons,
-                              linebetweenrows=None,
-                              linebelow=None,
-                              headerrow=DataRow("|", "|", "|"),
-                              datarow=DataRow("|", "|", "|"),
-                              padding=1,
-                              with_header_hide=["lineabove"]),
-                  "orgtbl":
-                  TableFormat(lineabove=None,
-                              linebelowheader=Line("|", "-", "+", "|"),
-                              linebetweenrows=None,
-                              linebelow=None,
-                              headerrow=DataRow("|", "|", "|"),
-                              datarow=DataRow("|", "|", "|"),
-                              padding=1, with_header_hide=None),
-                  "jira":
-                  TableFormat(lineabove=None,
-                              linebelowheader=None,
-                              linebetweenrows=None,
-                              linebelow=None,
-                              headerrow=DataRow("||", "||", "||"),
-                              datarow=DataRow("|", "|", "|"),
-                              padding=1, with_header_hide=None),
-                  "presto":
-                      TableFormat(lineabove=None,
-                                  linebelowheader=Line("", "-", "+", ""),
-                                  linebetweenrows=None,
-                                  linebelow=None,
-                                  headerrow=DataRow("", "|", ""),
-                                  datarow=DataRow("", "|", ""),
-                                  padding=1, with_header_hide=None),
-                  "psql":
-                  TableFormat(lineabove=Line("+", "-", "+", "+"),
-                              linebelowheader=Line("|", "-", "+", "|"),
-                              linebetweenrows=None,
-                              linebelow=Line("+", "-", "+", "+"),
-                              headerrow=DataRow("|", "|", "|"),
-                              datarow=DataRow("|", "|", "|"),
-                              padding=1, with_header_hide=None),
-                  "rst":
-                  TableFormat(lineabove=Line("", "=", "  ", ""),
-                              linebelowheader=Line("", "=", "  ", ""),
-                              linebetweenrows=None,
-                              linebelow=Line("", "=", "  ", ""),
-                              headerrow=DataRow("", "  ", ""),
-                              datarow=DataRow("", "  ", ""),
-                              padding=0, with_header_hide=None),
-                  "mediawiki":
-                  TableFormat(lineabove=Line("{| class=\"wikitable\" style=\"text-align: left;\"",
-                                             "", "", "\n|+ <!-- caption -->\n|-"),
-                              linebelowheader=Line("|-", "", "", ""),
-                              linebetweenrows=Line("|-", "", "", ""),
-                              linebelow=Line("|}", "", "", ""),
-                              headerrow=partial(_mediawiki_row_with_attrs, "!"),
-                              datarow=partial(_mediawiki_row_with_attrs, "|"),
-                              padding=0, with_header_hide=None),
-                  "moinmoin":
-                  TableFormat(lineabove=None,
-                              linebelowheader=None,
-                              linebetweenrows=None,
-                              linebelow=None,
-                              headerrow=partial(_moin_row_with_attrs,"||",header="'''"),
-                              datarow=partial(_moin_row_with_attrs,"||"),
-                              padding=1, with_header_hide=None),
-                  "youtrack":
-                  TableFormat(lineabove=None,
-                              linebelowheader=None,
-                              linebetweenrows=None,
-                              linebelow=None,
-                              headerrow=DataRow("|| ", " || ", " || "),
-                              datarow=DataRow("| ", " | ", " |"),
-                              padding=1, with_header_hide=None),
-                  "html":
-                  TableFormat(lineabove=_html_begin_table_without_header,
-                              linebelowheader="",
-                              linebetweenrows=None,
-                              linebelow=Line("</tbody>\n</table>", "", "", ""),
-                              headerrow=partial(_html_row_with_attrs, "th"),
-                              datarow=partial(_html_row_with_attrs, "td"),
-                              padding=0, with_header_hide=["lineabove"]),
-                  "latex":
-                  TableFormat(lineabove=_latex_line_begin_tabular,
-                              linebelowheader=Line("\\hline", "", "", ""),
-                              linebetweenrows=None,
-                              linebelow=Line("\\hline\n\\end{tabular}", "", "", ""),
-                              headerrow=_latex_row,
-                              datarow=_latex_row,
-                              padding=1, with_header_hide=None),
-                  "latex_raw":
-                  TableFormat(lineabove=_latex_line_begin_tabular,
-                              linebelowheader=Line("\\hline", "", "", ""),
-                              linebetweenrows=None,
-                              linebelow=Line("\\hline\n\\end{tabular}", "", "", ""),
-                              headerrow=partial(_latex_row, escrules={}),
-                              datarow=partial(_latex_row, escrules={}),
-                              padding=1, with_header_hide=None),
-                  "latex_booktabs":
-                  TableFormat(lineabove=partial(_latex_line_begin_tabular, booktabs=True),
-                              linebelowheader=Line("\\midrule", "", "", ""),
-                              linebetweenrows=None,
-                              linebelow=Line("\\bottomrule\n\\end{tabular}", "", "", ""),
-                              headerrow=_latex_row,
-                              datarow=_latex_row,
-                              padding=1, with_header_hide=None),
-                  "tsv":
-                  TableFormat(lineabove=None, linebelowheader=None,
-                              linebetweenrows=None, linebelow=None,
-                              headerrow=DataRow("", "\t", ""),
-                              datarow=DataRow("", "\t", ""),
-                              padding=0, with_header_hide=None),
-                  "textile":
-                  TableFormat(lineabove=None, linebelowheader=None,
-                              linebetweenrows=None, linebelow=None,
-                              headerrow=DataRow("|_. ", "|_.", "|"),
-                              datarow=_textile_row_with_attrs,
-                              padding=1, with_header_hide=None)}
+_table_formats = {
+    "simple": TableFormat(
+        lineabove=Line("", "-", "  ", ""),
+        linebelowheader=Line("", "-", "  ", ""),
+        linebetweenrows=None,
+        linebelow=Line("", "-", "  ", ""),
+        headerrow=DataRow("", "  ", ""),
+        datarow=DataRow("", "  ", ""),
+        padding=0,
+        with_header_hide=["lineabove", "linebelow"],
+    ),
+    "plain": TableFormat(
+        lineabove=None,
+        linebelowheader=None,
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("", "  ", ""),
+        datarow=DataRow("", "  ", ""),
+        padding=0,
+        with_header_hide=None,
+    ),
+    "grid": TableFormat(
+        lineabove=Line("+", "-", "+", "+"),
+        linebelowheader=Line("+", "=", "+", "+"),
+        linebetweenrows=Line("+", "-", "+", "+"),
+        linebelow=Line("+", "-", "+", "+"),
+        headerrow=DataRow("|", "|", "|"),
+        datarow=DataRow("|", "|", "|"),
+        padding=1,
+        with_header_hide=None,
+    ),
+    "fancy_grid": TableFormat(
+        lineabove=Line("╒", "═", "╤", "╕"),
+        linebelowheader=Line("╞", "═", "╪", "╡"),
+        linebetweenrows=Line("├", "─", "┼", "┤"),
+        linebelow=Line("╘", "═", "╧", "╛"),
+        headerrow=DataRow("│", "│", "│"),
+        datarow=DataRow("│", "│", "│"),
+        padding=1,
+        with_header_hide=None,
+    ),
+    "github": TableFormat(
+        lineabove=Line("|", "-", "|", "|"),
+        linebelowheader=Line("|", "-", "|", "|"),
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("|", "|", "|"),
+        datarow=DataRow("|", "|", "|"),
+        padding=1,
+        with_header_hide=["lineabove"],
+    ),
+    "pipe": TableFormat(
+        lineabove=_pipe_line_with_colons,
+        linebelowheader=_pipe_line_with_colons,
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("|", "|", "|"),
+        datarow=DataRow("|", "|", "|"),
+        padding=1,
+        with_header_hide=["lineabove"],
+    ),
+    "orgtbl": TableFormat(
+        lineabove=None,
+        linebelowheader=Line("|", "-", "+", "|"),
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("|", "|", "|"),
+        datarow=DataRow("|", "|", "|"),
+        padding=1,
+        with_header_hide=None,
+    ),
+    "jira": TableFormat(
+        lineabove=None,
+        linebelowheader=None,
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("||", "||", "||"),
+        datarow=DataRow("|", "|", "|"),
+        padding=1,
+        with_header_hide=None,
+    ),
+    "presto": TableFormat(
+        lineabove=None,
+        linebelowheader=Line("", "-", "+", ""),
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("", "|", ""),
+        datarow=DataRow("", "|", ""),
+        padding=1,
+        with_header_hide=None,
+    ),
+    "psql": TableFormat(
+        lineabove=Line("+", "-", "+", "+"),
+        linebelowheader=Line("|", "-", "+", "|"),
+        linebetweenrows=None,
+        linebelow=Line("+", "-", "+", "+"),
+        headerrow=DataRow("|", "|", "|"),
+        datarow=DataRow("|", "|", "|"),
+        padding=1,
+        with_header_hide=None,
+    ),
+    "rst": TableFormat(
+        lineabove=Line("", "=", "  ", ""),
+        linebelowheader=Line("", "=", "  ", ""),
+        linebetweenrows=None,
+        linebelow=Line("", "=", "  ", ""),
+        headerrow=DataRow("", "  ", ""),
+        datarow=DataRow("", "  ", ""),
+        padding=0,
+        with_header_hide=None,
+    ),
+    "mediawiki": TableFormat(
+        lineabove=Line(
+            '{| class="wikitable" style="text-align: left;"',
+            "",
+            "",
+            "\n|+ <!-- caption -->\n|-",
+        ),
+        linebelowheader=Line("|-", "", "", ""),
+        linebetweenrows=Line("|-", "", "", ""),
+        linebelow=Line("|}", "", "", ""),
+        headerrow=partial(_mediawiki_row_with_attrs, "!"),
+        datarow=partial(_mediawiki_row_with_attrs, "|"),
+        padding=0,
+        with_header_hide=None,
+    ),
+    "moinmoin": TableFormat(
+        lineabove=None,
+        linebelowheader=None,
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=partial(_moin_row_with_attrs, "||", header="'''"),
+        datarow=partial(_moin_row_with_attrs, "||"),
+        padding=1,
+        with_header_hide=None,
+    ),
+    "youtrack": TableFormat(
+        lineabove=None,
+        linebelowheader=None,
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("|| ", " || ", " || "),
+        datarow=DataRow("| ", " | ", " |"),
+        padding=1,
+        with_header_hide=None,
+    ),
+    "html": TableFormat(
+        lineabove=_html_begin_table_without_header,
+        linebelowheader="",
+        linebetweenrows=None,
+        linebelow=Line("</tbody>\n</table>", "", "", ""),
+        headerrow=partial(_html_row_with_attrs, "th"),
+        datarow=partial(_html_row_with_attrs, "td"),
+        padding=0,
+        with_header_hide=["lineabove"],
+    ),
+    "latex": TableFormat(
+        lineabove=_latex_line_begin_tabular,
+        linebelowheader=Line("\\hline", "", "", ""),
+        linebetweenrows=None,
+        linebelow=Line("\\hline\n\\end{tabular}", "", "", ""),
+        headerrow=_latex_row,
+        datarow=_latex_row,
+        padding=1,
+        with_header_hide=None,
+    ),
+    "latex_raw": TableFormat(
+        lineabove=_latex_line_begin_tabular,
+        linebelowheader=Line("\\hline", "", "", ""),
+        linebetweenrows=None,
+        linebelow=Line("\\hline\n\\end{tabular}", "", "", ""),
+        headerrow=partial(_latex_row, escrules={}),
+        datarow=partial(_latex_row, escrules={}),
+        padding=1,
+        with_header_hide=None,
+    ),
+    "latex_booktabs": TableFormat(
+        lineabove=partial(_latex_line_begin_tabular, booktabs=True),
+        linebelowheader=Line("\\midrule", "", "", ""),
+        linebetweenrows=None,
+        linebelow=Line("\\bottomrule\n\\end{tabular}", "", "", ""),
+        headerrow=_latex_row,
+        datarow=_latex_row,
+        padding=1,
+        with_header_hide=None,
+    ),
+    "tsv": TableFormat(
+        lineabove=None,
+        linebelowheader=None,
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("", "\t", ""),
+        datarow=DataRow("", "\t", ""),
+        padding=0,
+        with_header_hide=None,
+    ),
+    "textile": TableFormat(
+        lineabove=None,
+        linebelowheader=None,
+        linebetweenrows=None,
+        linebelow=None,
+        headerrow=DataRow("|_. ", "|_.", "|"),
+        datarow=_textile_row_with_attrs,
+        padding=1,
+        with_header_hide=None,
+    ),
+}
 
 
 tabulate_formats = list(sorted(_table_formats.keys()))
@@ -387,16 +476,16 @@ tabulate_formats = list(sorted(_table_formats.keys()))
 # table rows. The key is the original format specified at the API. The value is
 # the format that will be used to represent the original format.
 multiline_formats = {
-        "plain": "plain",
-        "simple": "simple",
-        "grid": "grid",
-        "fancy_grid": "fancy_grid",
-        "pipe": "pipe",
-        "orgtbl": "orgtbl",
-        "jira": "jira",
-        "presto": "presto",
-        "psql": "psql",
-        "rst": "rst",
+    "plain": "plain",
+    "simple": "simple",
+    "grid": "grid",
+    "fancy_grid": "fancy_grid",
+    "pipe": "pipe",
+    "orgtbl": "orgtbl",
+    "jira": "jira",
+    "presto": "presto",
+    "psql": "psql",
+    "rst": "rst",
 }
 
 # TODO: Add multiline support for the remaining table formats:
@@ -411,8 +500,12 @@ multiline_formats = {
 
 _multiline_codes = re.compile(r"\r|\n|\r\n")
 _multiline_codes_bytes = re.compile(b"\r|\n|\r\n")
-_invisible_codes = re.compile(r"\x1b\[\d+[;\d]*m|\x1b\[\d*\;\d*\;\d*m")  # ANSI color codes
-_invisible_codes_bytes = re.compile(b"\x1b\[\d+[;\d]*m|\x1b\[\d*\;\d*\;\d*m")  # ANSI color codes
+_invisible_codes = re.compile(
+    r"\x1b\[\d+[;\d]*m|\x1b\[\d*\;\d*\;\d*m"
+)  # ANSI color codes
+_invisible_codes_bytes = re.compile(
+    b"\x1b\\[\\d+\\[;\\d]*m|\x1b\\[\\d*;\\d*;\\d*m"
+)  # ANSI color codes
 
 
 def simple_separated_format(separator):
@@ -423,15 +516,21 @@ def simple_separated_format(separator):
     True
 
     """
-    return TableFormat(None, None, None, None,
-                       headerrow=DataRow('', separator, ''),
-                       datarow=DataRow('', separator, ''),
-                       padding=0, with_header_hide=None)
+    return TableFormat(
+        None,
+        None,
+        None,
+        None,
+        headerrow=DataRow("", separator, ""),
+        datarow=DataRow("", separator, ""),
+        padding=0,
+        with_header_hide=None,
+    )
 
 
 def _isconvertible(conv, string):
     try:
-        n = conv(string)
+        conv(string)
         return True
     except (ValueError, TypeError):
         return False
@@ -453,8 +552,9 @@ def _isnumber(string):
     if not _isconvertible(float, string):
         return False
     elif isinstance(string, (_text_type, _binary_type)) and (
-            math.isinf(float(string)) or math.isnan(float(string))):
-        return string.lower() in ['inf', '-inf', 'nan']
+        math.isinf(float(string)) or math.isnan(float(string))
+    ):
+        return string.lower() in ["inf", "-inf", "nan"]
     return True
 
 
@@ -465,10 +565,11 @@ def _isint(string, inttype=int):
     >>> _isint("123.45")
     False
     """
-    return type(string) is inttype or\
-           (isinstance(string, _binary_type) or isinstance(string, _text_type))\
-            and\
-            _isconvertible(inttype, string)
+    return (
+        type(string) is inttype
+        or (isinstance(string, _binary_type) or isinstance(string, _text_type))
+        and _isconvertible(inttype, string)
+    )
 
 
 def _isbool(string):
@@ -480,10 +581,9 @@ def _isbool(string):
     >>> _isbool(1)
     False
     """
-    return type(string) is _bool_type or\
-           (isinstance(string, (_binary_type, _text_type))\
-            and\
-            string in ("True", "False"))
+    return type(string) is _bool_type or (
+        isinstance(string, (_binary_type, _text_type)) and string in ("True", "False")
+    )
 
 
 def _type(string, has_invisible=True, numparse=True):
@@ -502,8 +602,9 @@ def _type(string, has_invisible=True, numparse=True):
 
     """
 
-    if has_invisible and \
-       (isinstance(string, _text_type) or isinstance(string, _binary_type)):
+    if has_invisible and (
+        isinstance(string, _text_type) or isinstance(string, _binary_type)
+    ):
         string = _strip_invisible(string)
 
     if string is None:
@@ -630,12 +731,12 @@ def _choose_width_fn(has_invisible, enable_widechars, is_multiline):
     """Return a function to calculate visible cell width."""
     if has_invisible:
         line_width_fn = _visible_width
-    elif enable_widechars: # optional wide-character support if available
+    elif enable_widechars:  # optional wide-character support if available
         line_width_fn = wcwidth.wcswidth
     else:
         line_width_fn = len
     if is_multiline:
-        width_fn = lambda s: _multiline_width(s, line_width_fn)
+        width_fn = lambda s: _multiline_width(s, line_width_fn)  # noqa
     else:
         width_fn = line_width_fn
     return width_fn
@@ -656,8 +757,7 @@ def _align_column_choose_padfn(strings, alignment, has_invisible):
         else:
             decimals = [_afterpoint(s) for s in strings]
         maxdecimals = max(decimals)
-        strings = [s + (maxdecimals - decs) * " "
-                   for s, decs in zip(strings, decimals)]
+        strings = [s + (maxdecimals - decs) * " " for s, decs in zip(strings, decimals)]
         padfn = _padleft
     elif not alignment:
         padfn = _padnone
@@ -668,8 +768,14 @@ def _align_column_choose_padfn(strings, alignment, has_invisible):
     return strings, padfn
 
 
-def _align_column(strings, alignment, minwidth=0,
-                  has_invisible=True, enable_widechars=False, is_multiline=False):
+def _align_column(
+    strings,
+    alignment,
+    minwidth=0,
+    has_invisible=True,
+    enable_widechars=False,
+    is_multiline=False,
+):
     """[string] -> [padded_string]"""
     strings, padfn = _align_column_choose_padfn(strings, alignment, has_invisible)
     width_fn = _choose_width_fn(has_invisible, enable_widechars, is_multiline)
@@ -681,15 +787,18 @@ def _align_column(strings, alignment, minwidth=0,
         if not enable_widechars and not has_invisible:
             padded_strings = [
                 "\n".join([padfn(maxwidth, s) for s in ms.splitlines()])
-                for ms in strings]
+                for ms in strings
+            ]
         else:
             # enable wide-character width corrections
             s_lens = [max((len(s) for s in re.split("[\r\n]", ms))) for ms in strings]
             visible_widths = [maxwidth - (w - l) for w, l in zip(s_widths, s_lens)]
             # wcswidth and _visible_width don't count invisible characters;
             # padfn doesn't need to apply another correction
-            padded_strings = ["\n".join([padfn(w, s) for s in (ms.splitlines() or ms)])
-                              for ms, w in zip(strings, visible_widths)]
+            padded_strings = [
+                "\n".join([padfn(w, s) for s in (ms.splitlines() or ms)])
+                for ms, w in zip(strings, visible_widths)
+            ]
     else:  # single-line cell values
         if not enable_widechars and not has_invisible:
             padded_strings = [padfn(maxwidth, s) for s in strings]
@@ -704,8 +813,22 @@ def _align_column(strings, alignment, minwidth=0,
 
 
 def _more_generic(type1, type2):
-    types = { _none_type: 0, _bool_type: 1, int: 2, float: 3, _binary_type: 4, _text_type: 5 }
-    invtypes = { 5: _text_type, 4: _binary_type, 3: float, 2: int, 1: _bool_type, 0: _none_type }
+    types = {
+        _none_type: 0,
+        _bool_type: 1,
+        int: 2,
+        float: 3,
+        _binary_type: 4,
+        _text_type: 5,
+    }
+    invtypes = {
+        5: _text_type,
+        4: _binary_type,
+        3: float,
+        2: int,
+        1: _bool_type,
+        0: _none_type,
+    }
     moregeneric = max(types.get(type1, 5), types.get(type2, 5))
     return invtypes[moregeneric]
 
@@ -732,7 +855,7 @@ def _column_type(strings, has_invisible=True, numparse=True):
     True
 
     """
-    types = [_type(s, has_invisible, numparse) for s in strings ]
+    types = [_type(s, has_invisible, numparse) for s in strings]
     return reduce(_more_generic, types, _bool_type)
 
 
@@ -747,7 +870,7 @@ def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
         tabulate(tbl, headers=hrow) == good_result
     True
 
-    """
+    """  # noqa
     if val is None:
         return missingval
 
@@ -759,7 +882,9 @@ def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
         except TypeError:
             return _text_type(val)
     elif valtype is float:
-        is_a_colored_number = has_invisible and isinstance(val, (_text_type, _binary_type))
+        is_a_colored_number = has_invisible and isinstance(
+            val, (_text_type, _binary_type)
+        )
         if is_a_colored_number:
             raw_val = _strip_invisible(val)
             formatted_val = format(float(raw_val), floatfmt)
@@ -770,11 +895,15 @@ def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
         return "{0}".format(val)
 
 
-def _align_header(header, alignment, width, visible_width, is_multiline=False, width_fn=None):
+def _align_header(
+    header, alignment, width, visible_width, is_multiline=False, width_fn=None
+):
     "Pad string header to width chars given known visible_width of the header."
     if is_multiline:
         header_lines = re.split(_multiline_codes, header)
-        padded_lines = [_align_header(h, alignment, width, width_fn(h)) for h in header_lines]
+        padded_lines = [
+            _align_header(h, alignment, width, width_fn(h)) for h in header_lines
+        ]
         return "\n".join(padded_lines)
     # else: not multiline
     ninvisible = len(header) - visible_width
@@ -794,10 +923,10 @@ def _prepend_row_index(rows, index):
     if index is None or index is False:
         return rows
     if len(index) != len(rows):
-        print('index=', index)
-        print('rows=', rows)
-        raise ValueError('index must be as long as the number of data rows')
-    rows = [[v]+list(row) for v,row in zip(index, rows)]
+        print("index=", index)
+        print("rows=", rows)
+        raise ValueError("index must be as long as the number of data rows")
+    rows = [[v] + list(row) for v, row in zip(index, rows)]
     return rows
 
 
@@ -842,9 +971,9 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
 
     try:
         bool(headers)
-        is_headers2bool_broken = False
-    except ValueError: # numpy.ndarray, pandas.core.index.Index, ...
-        is_headers2bool_broken = True
+        is_headers2bool_broken = False  # noqa
+    except ValueError:  # numpy.ndarray, pandas.core.index.Index, ...
+        is_headers2bool_broken = True  # noqa
         headers = list(headers)
 
     index = None
@@ -853,7 +982,9 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
         if hasattr(tabular_data.values, "__call__"):
             # likely a conventional dict
             keys = tabular_data.keys()
-            rows = list(izip_longest(*tabular_data.values()))  # columns have to be transposed
+            rows = list(
+                izip_longest(*tabular_data.values())
+            )  # columns have to be transposed
         elif hasattr(tabular_data, "index"):
             # values is a property, has .index => it's likely a pandas.DataFrame (pandas 0.11.0)
             keys = list(tabular_data)
@@ -870,30 +1001,33 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
             raise ValueError("tabular data doesn't appear to be a dict or a DataFrame")
 
         if headers == "keys":
-            headers = list(map(_text_type,keys))  # headers should be strings
+            headers = list(map(_text_type, keys))  # headers should be strings
 
     else:  # it's a usual an iterable of iterables, or a NumPy array
         rows = list(tabular_data)
 
-        if (headers == "keys" and not rows):
+        if headers == "keys" and not rows:
             # an empty table (issue #81)
             headers = []
-        elif (headers == "keys" and
-            hasattr(tabular_data, "dtype") and
-            getattr(tabular_data.dtype, "names")):
+        elif (
+            headers == "keys"
+            and hasattr(tabular_data, "dtype")
+            and getattr(tabular_data.dtype, "names")
+        ):
             # numpy record array
             headers = tabular_data.dtype.names
-        elif (headers == "keys"
-              and len(rows) > 0
-              and isinstance(rows[0], tuple)
-              and hasattr(rows[0], "_fields")):
+        elif (
+            headers == "keys"
+            and len(rows) > 0
+            and isinstance(rows[0], tuple)
+            and hasattr(rows[0], "_fields")
+        ):
             # namedtuple
             headers = list(map(_text_type, rows[0]._fields))
-        elif (len(rows) > 0
-              and isinstance(rows[0], dict)):
+        elif len(rows) > 0 and isinstance(rows[0], dict):
             # dict or OrderedDict
-            uniq_keys = set() # implements hashed lookup
-            keys = [] # storage for set
+            uniq_keys = set()  # implements hashed lookup
+            keys = []  # storage for set
             if headers == "firstrow":
                 firstdict = rows[0] if len(rows) > 0 else {}
                 keys.extend(firstdict.keys())
@@ -901,11 +1035,11 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
                 rows = rows[1:]
             for row in rows:
                 for k in row.keys():
-                    #Save unique items in input order
+                    # Save unique items in input order
                     if k not in uniq_keys:
                         keys.append(k)
                         uniq_keys.add(k)
-            if headers == 'keys':
+            if headers == "keys":
                 headers = keys
             elif isinstance(headers, dict):
                 # a dict of headers for a list of dicts
@@ -918,13 +1052,17 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
                 else:
                     headers = []
             elif headers:
-                raise ValueError('headers for a list of dicts is not a dict or a keyword')
+                raise ValueError(
+                    "headers for a list of dicts is not a dict or a keyword"
+                )
             rows = [[row.get(k) for k in keys] for row in rows]
 
-        elif (headers == "keys"
-              and hasattr(tabular_data, "description")
-              and hasattr(tabular_data, "fetchone")
-              and hasattr(tabular_data, "rowcount")):
+        elif (
+            headers == "keys"
+            and hasattr(tabular_data, "description")
+            and hasattr(tabular_data, "fetchone")
+            and hasattr(tabular_data, "rowcount")
+        ):
             # Python Database API cursor object (PEP 0249)
             # print tabulate(cursor, headers='keys')
             headers = [column[0] for column in tabular_data.description]
@@ -940,11 +1078,11 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
             index = index[1:]
         else:
             headers = rows[0]
-        headers = list(map(_text_type, headers)) # headers should be strings
+        headers = list(map(_text_type, headers))  # headers should be strings
         rows = rows[1:]
 
-    headers = list(map(_text_type,headers))
-    rows = list(map(list,rows))
+    headers = list(map(_text_type, headers))
+    rows = list(map(list, rows))
 
     # add or remove an index column
     showindex_is_a_str = type(showindex) in [_text_type, _binary_type]
@@ -961,19 +1099,26 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
 
     # pad with empty headers for initial columns if necessary
     if headers and len(rows) > 0:
-       nhs = len(headers)
-       ncols = len(rows[0])
-       if nhs < ncols:
-           headers = [""]*(ncols - nhs) + headers
+        nhs = len(headers)
+        ncols = len(rows[0])
+        if nhs < ncols:
+            headers = [""] * (ncols - nhs) + headers
 
     return rows, headers
 
 
-
-def tabulate(tabular_data, headers=(), tablefmt="simple",
-             floatfmt=_DEFAULT_FLOATFMT, numalign="decimal", stralign="left",
-             missingval=_DEFAULT_MISSINGVAL, showindex="default", disable_numparse=False,
-             colalign=None):
+def tabulate(
+    tabular_data,
+    headers=(),
+    tablefmt="simple",
+    floatfmt=_DEFAULT_FLOATFMT,
+    numalign="decimal",
+    stralign="left",
+    missingval=_DEFAULT_MISSINGVAL,
+    showindex="default",
+    disable_numparse=False,
+    colalign=None,
+):
     """Format a fixed width table for pretty printing.
 
     >>> print(tabulate([[1, 2.34], [-56, "8.999"], ["2", "10001"]]))
@@ -1240,7 +1385,7 @@ def tabulate(tabular_data, headers=(), tablefmt="simple",
      spam &  41.9999 \\\\
      eggs & 451      \\\\
     \\bottomrule
-    \end{tabular}
+    \\end{tabular}
 
     Number parsing
     --------------
@@ -1259,17 +1404,20 @@ def tabulate(tabular_data, headers=(), tablefmt="simple",
     if tabular_data is None:
         tabular_data = []
     list_of_lists, headers = _normalize_tabular_data(
-            tabular_data, headers, showindex=showindex)
+        tabular_data, headers, showindex=showindex
+    )
 
     # empty values in the first column of RST tables should be escaped (issue #82)
     # "" should be escaped as "\\ " or ".."
-    if tablefmt == 'rst':
+    if tablefmt == "rst":
         list_of_lists, headers = _rst_escape_first_column(list_of_lists, headers)
 
     # optimization: look for ANSI control codes once,
     # enable smart width functions only if a control code is found
-    plain_text = '\t'.join(['\t'.join(map(_text_type, headers))] + \
-                            ['\t'.join(map(_text_type, row)) for row in list_of_lists])
+    plain_text = "\t".join(
+        ["\t".join(map(_text_type, headers))]
+        + ["\t".join(map(_text_type, row)) for row in list_of_lists]
+    )
 
     has_invisible = re.search(_invisible_codes, plain_text)
     enable_widechars = wcwidth is not None and WIDE_CHARS_MODE
@@ -1283,40 +1431,52 @@ def tabulate(tabular_data, headers=(), tablefmt="simple",
     # format rows and columns, convert numeric values to strings
     cols = list(izip_longest(*list_of_lists))
     numparses = _expand_numparse(disable_numparse, len(cols))
-    coltypes = [_column_type(col, numparse=np) for col, np in
-                zip(cols, numparses)]
-    if isinstance(floatfmt, basestring): #old version
-        float_formats = len(cols) * [floatfmt] # just duplicate the string to use in each column
-    else: # if floatfmt is list, tuple etc we have one per column
+    coltypes = [_column_type(col, numparse=np) for col, np in zip(cols, numparses)]
+    if isinstance(floatfmt, basestring):  # old version
+        float_formats = len(cols) * [
+            floatfmt
+        ]  # just duplicate the string to use in each column
+    else:  # if floatfmt is list, tuple etc we have one per column
         float_formats = list(floatfmt)
         if len(float_formats) < len(cols):
-            float_formats.extend( (len(cols)-len(float_formats)) * [_DEFAULT_FLOATFMT] )
+            float_formats.extend((len(cols) - len(float_formats)) * [_DEFAULT_FLOATFMT])
     if isinstance(missingval, basestring):
         missing_vals = len(cols) * [missingval]
     else:
         missing_vals = list(missingval)
         if len(missing_vals) < len(cols):
-            missing_vals.extend( (len(cols)-len(missing_vals)) * [_DEFAULT_MISSINGVAL] )
-    cols = [[_format(v, ct, fl_fmt, miss_v, has_invisible) for v in c]
-             for c, ct, fl_fmt, miss_v in zip(cols, coltypes, float_formats, missing_vals)]
+            missing_vals.extend((len(cols) - len(missing_vals)) * [_DEFAULT_MISSINGVAL])
+    cols = [
+        [_format(v, ct, fl_fmt, miss_v, has_invisible) for v in c]
+        for c, ct, fl_fmt, miss_v in zip(cols, coltypes, float_formats, missing_vals)
+    ]
 
     # align columns
-    aligns = [numalign if ct in [int,float] else stralign for ct in coltypes]
+    aligns = [numalign if ct in [int, float] else stralign for ct in coltypes]
     if colalign is not None:
         assert isinstance(colalign, Iterable)
         for idx, align in enumerate(colalign):
             aligns[idx] = align
-    minwidths = [width_fn(h) + MIN_PADDING for h in headers] if headers else [0]*len(cols)
-    cols = [_align_column(c, a, minw, has_invisible, enable_widechars, is_multiline)
-            for c, a, minw in zip(cols, aligns, minwidths)]
+    minwidths = (
+        [width_fn(h) + MIN_PADDING for h in headers] if headers else [0] * len(cols)
+    )
+    cols = [
+        _align_column(c, a, minw, has_invisible, enable_widechars, is_multiline)
+        for c, a, minw in zip(cols, aligns, minwidths)
+    ]
 
     if headers:
         # align headers and add headers
-        t_cols = cols or [['']] * len(headers)
+        t_cols = cols or [[""]] * len(headers)
         t_aligns = aligns or [stralign] * len(headers)
-        minwidths = [max(minw, max(width_fn(cl) for cl in c)) for minw, c in zip(minwidths, t_cols)]
-        headers = [_align_header(h, a, minw, width_fn(h), is_multiline, width_fn)
-                   for h, a, minw in zip(headers, t_aligns, minwidths)]
+        minwidths = [
+            max(minw, max(width_fn(cl) for cl in c))
+            for minw, c in zip(minwidths, t_cols)
+        ]
+        headers = [
+            _align_header(h, a, minw, width_fn(h), is_multiline, width_fn)
+            for h, a, minw in zip(headers, t_aligns, minwidths)
+        ]
         rows = list(zip(*cols))
     else:
         minwidths = [max(width_fn(cl) for cl in c) for c in cols]
@@ -1347,7 +1507,7 @@ def _expand_numparse(disable_numparse, column_count):
 
 def _pad_row(cells, padding):
     if cells:
-        pad = " "*padding
+        pad = " " * padding
         padded_cells = [pad + cell + pad for cell in cells]
         return padded_cells
     else:
@@ -1375,12 +1535,16 @@ def _append_basic_row(lines, padded_cells, colwidths, colaligns, rowfmt):
     return lines
 
 
-def _append_multiline_row(lines, padded_multiline_cells, padded_widths, colaligns, rowfmt, pad):
-    colwidths = [w - 2*pad for w in padded_widths]
+def _append_multiline_row(
+    lines, padded_multiline_cells, padded_widths, colaligns, rowfmt, pad
+):
+    colwidths = [w - 2 * pad for w in padded_widths]
     cells_lines = [c.splitlines() for c in padded_multiline_cells]
-    nlines = max(map(len, cells_lines)) # number of lines in the row
+    nlines = max(map(len, cells_lines))  # number of lines in the row
     # vertically pad cells where some lines are missing
-    cells_lines = [(cl + [' '*w]*(nlines - len(cl))) for cl, w in zip(cells_lines, colwidths)]
+    cells_lines = [
+        (cl + [" " * w] * (nlines - len(cl))) for cl, w in zip(cells_lines, colwidths)
+    ]
     lines_cells = [[cl[i] for cl in cells_lines] for i in range(nlines)]
     for ln in lines_cells:
         padded_ln = _pad_row(ln, pad)
@@ -1395,8 +1559,8 @@ def _build_line(colwidths, colaligns, linefmt):
     if hasattr(linefmt, "__call__"):
         return linefmt(colwidths, colaligns)
     else:
-        begin, fill, sep,  end = linefmt
-        cells = [fill*w for w in colwidths]
+        begin, fill, sep, end = linefmt
+        cells = [fill * w for w in colwidths]
         return _build_simple_row(cells, (begin, sep, end))
 
 
@@ -1412,9 +1576,9 @@ def _format_table(fmt, headers, rows, colwidths, colaligns, is_multiline):
     pad = fmt.padding
     headerrow = fmt.headerrow
 
-    padded_widths = [(w + 2*pad) for w in colwidths]
+    padded_widths = [(w + 2 * pad) for w in colwidths]
     if is_multiline:
-        pad_row = lambda row, _: row  # do it later, in _append_multiline_row
+        pad_row = lambda row, _: row  # noqa do it later, in _append_multiline_row
         append_row = partial(_append_multiline_row, pad=pad)
     else:
         pad_row = _pad_row
@@ -1447,7 +1611,7 @@ def _format_table(fmt, headers, rows, colwidths, colaligns, is_multiline):
 
     if headers or rows:
         return "\n".join(lines)
-    else: # a completely empty table
+    else:  # a completely empty table
         return ""
 
 
@@ -1477,12 +1641,14 @@ def _main():
     import getopt
     import sys
     import textwrap
+
     usage = textwrap.dedent(_main.__doc__)
     try:
-        opts, args = getopt.getopt(sys.argv[1:],
-                     "h1o:s:F:A:f:",
-                     ["help", "header", "output", "sep=", "float=", "align=",
-                      "format="])
+        opts, args = getopt.getopt(
+            sys.argv[1:],
+            "h1o:s:F:A:f:",
+            ["help", "header", "output", "sep=", "float=", "align=", "format="],
+        )
     except getopt.GetoptError as e:
         print(e)
         print(usage)
@@ -1519,21 +1685,35 @@ def _main():
             if f == "-":
                 f = sys.stdin
             if _is_file(f):
-                _pprint_file(f, headers=headers, tablefmt=tablefmt,
-                             sep=sep, floatfmt=floatfmt, file=out,
-                             colalign=colalign)
+                _pprint_file(
+                    f,
+                    headers=headers,
+                    tablefmt=tablefmt,
+                    sep=sep,
+                    floatfmt=floatfmt,
+                    file=out,
+                    colalign=colalign,
+                )
             else:
                 with open(f) as fobj:
-                    _pprint_file(fobj, headers=headers, tablefmt=tablefmt,
-                                 sep=sep, floatfmt=floatfmt, file=out,
-                                 colalign=colalign)
+                    _pprint_file(
+                        fobj,
+                        headers=headers,
+                        tablefmt=tablefmt,
+                        sep=sep,
+                        floatfmt=floatfmt,
+                        file=out,
+                        colalign=colalign,
+                    )
 
 
 def _pprint_file(fobject, headers, tablefmt, sep, floatfmt, file, colalign):
     rows = fobject.readlines()
     table = [re.split(sep, r.rstrip()) for r in rows if r.strip()]
-    print(tabulate(table, headers, tablefmt, floatfmt=floatfmt,
-          colalign=colalign), file=file)
+    print(
+        tabulate(table, headers, tablefmt, floatfmt=floatfmt, colalign=colalign),
+        file=file,
+    )
 
 
 if __name__ == "__main__":

--- a/test/common.py
+++ b/test/common.py
@@ -7,9 +7,11 @@ except ImportError:
         try:
             from unittest2.case import SkipTest  # Python < 2.7
         except ImportError:
+
             class SkipTest(Exception):
                 """Raise this exception to mark a test as skipped.
                 """
+
                 pass
 
 
@@ -18,25 +20,26 @@ try:
 
 
 except ImportError:
+
     def assert_equal(expected, result):
         print("Expected:\n%s\n" % expected)
         print("Got:\n%s\n" % result)
         assert expected == result
 
-
     def assert_in(result, expected_set):
-        nums = xrange(1, len(expected_set)+1)
+        nums = range(1, len(expected_set) + 1)
         for i, expected in zip(nums, expected_set):
             print("Expected %d:\n%s\n" % (i, expected))
         print("Got:\n%s\n" % result)
         assert result in expected_set
 
-
     class assert_raises(object):
         def __init__(self, exception_type):
             self.watch_exception_type = exception_type
+
         def __enter__(self):
             pass
+
         def __exit__(self, exception_type, exception_value, traceback):
             if isinstance(exception_value, self.watch_exception_type):
                 return True  # suppress exception

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -10,7 +10,7 @@ from common import SkipTest
 
 
 try:
-    if python_version_tuple() >= ('3','3','0'):
+    if python_version_tuple() >= ("3", "3", "0"):
         from inspect import signature, _empty
     else:
         signature = None
@@ -21,12 +21,12 @@ except ImportError:
 
 
 def test_tabulate_formats():
-    "API: tabulate_formats is a list of strings"""
+    "API: tabulate_formats is a list of strings" ""
     supported = tabulate_formats
     print("tabulate_formats = %r" % supported)
     assert type(supported) is list
     for fmt in supported:
-        assert type(fmt) is type("")
+        assert type(fmt) is type("")  # noqa
 
 
 def _check_signature(function, expected_sig):
@@ -39,20 +39,22 @@ def _check_signature(function, expected_sig):
 
 
 def test_tabulate_signature():
-    "API: tabulate() type signature is unchanged"""
-    assert type(tabulate) is type(lambda: None)
-    expected_sig = [("tabular_data", _empty),
-                    ("headers", ()),
-                    ("tablefmt", "simple"),
-                    ("floatfmt", "g"),
-                    ("numalign", "decimal"),
-                    ("stralign", "left"),
-                    ("missingval", "")]
+    "API: tabulate() type signature is unchanged" ""
+    assert type(tabulate) is type(lambda: None)  # noqa
+    expected_sig = [
+        ("tabular_data", _empty),
+        ("headers", ()),
+        ("tablefmt", "simple"),
+        ("floatfmt", "g"),
+        ("numalign", "decimal"),
+        ("stralign", "left"),
+        ("missingval", ""),
+    ]
     _check_signature(tabulate, expected_sig)
 
 
 def test_simple_separated_format_signature():
-    "API: simple_separated_format() type signature is unchanged"""
-    assert type(simple_separated_format) is type(lambda: None)
+    "API: simple_separated_format() type signature is unchanged" ""
+    assert type(simple_separated_format) is type(lambda: None)  # noqa
     expected_sig = [("separator", _empty)]
     _check_signature(simple_separated_format, expected_sig)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -17,65 +17,78 @@ from common import assert_equal
 
 
 SAMPLE_SIMPLE_FORMAT = "\n".join(
-    ['-----  ------  -------------',
-     'Sun    696000     1.9891e+09',
-     'Earth    6371  5973.6',
-     'Moon     1737    73.5',
-     'Mars     3390   641.85',
-     '-----  ------  -------------'])
+    [
+        "-----  ------  -------------",
+        "Sun    696000     1.9891e+09",
+        "Earth    6371  5973.6",
+        "Moon     1737    73.5",
+        "Mars     3390   641.85",
+        "-----  ------  -------------",
+    ]
+)
 
 
 SAMPLE_SIMPLE_FORMAT_WITH_HEADERS = "\n".join(
-    ['Planet      Radius           Mass',
-     '--------  --------  -------------',
-     'Sun         696000     1.9891e+09',
-     'Earth         6371  5973.6',
-     'Moon          1737    73.5',
-     'Mars          3390   641.85'])
+    [
+        "Planet      Radius           Mass",
+        "--------  --------  -------------",
+        "Sun         696000     1.9891e+09",
+        "Earth         6371  5973.6",
+        "Moon          1737    73.5",
+        "Mars          3390   641.85",
+    ]
+)
 
 
 SAMPLE_GRID_FORMAT_WITH_HEADERS = "\n".join(
-    ['+----------+----------+---------------+',
-     '| Planet   |   Radius |          Mass |',
-     '+==========+==========+===============+',
-     '| Sun      |   696000 |    1.9891e+09 |',
-     '+----------+----------+---------------+',
-     '| Earth    |     6371 | 5973.6        |',
-     '+----------+----------+---------------+',
-     '| Moon     |     1737 |   73.5        |',
-     '+----------+----------+---------------+',
-     '| Mars     |     3390 |  641.85       |',
-     '+----------+----------+---------------+'])
+    [
+        "+----------+----------+---------------+",
+        "| Planet   |   Radius |          Mass |",
+        "+==========+==========+===============+",
+        "| Sun      |   696000 |    1.9891e+09 |",
+        "+----------+----------+---------------+",
+        "| Earth    |     6371 | 5973.6        |",
+        "+----------+----------+---------------+",
+        "| Moon     |     1737 |   73.5        |",
+        "+----------+----------+---------------+",
+        "| Mars     |     3390 |  641.85       |",
+        "+----------+----------+---------------+",
+    ]
+)
 
 
 SAMPLE_GRID_FORMAT_WITH_DOT1E_FLOATS = "\n".join(
-    ['+-------+--------+---------+',
-     '| Sun   | 696000 | 2.0e+09 |',
-     '+-------+--------+---------+',
-     '| Earth |   6371 | 6.0e+03 |',
-     '+-------+--------+---------+',
-     '| Moon  |   1737 | 7.4e+01 |',
-     '+-------+--------+---------+',
-     '| Mars  |   3390 | 6.4e+02 |',
-     '+-------+--------+---------+'])
+    [
+        "+-------+--------+---------+",
+        "| Sun   | 696000 | 2.0e+09 |",
+        "+-------+--------+---------+",
+        "| Earth |   6371 | 6.0e+03 |",
+        "+-------+--------+---------+",
+        "| Moon  |   1737 | 7.4e+01 |",
+        "+-------+--------+---------+",
+        "| Mars  |   3390 | 6.4e+02 |",
+        "+-------+--------+---------+",
+    ]
+)
 
 
-def sample_input(sep=' ', with_headers=False):
-    headers = sep.join(['Planet', 'Radius', 'Mass'])
-    rows = [sep.join(['Sun', '696000', '1.9891e9']),
-            sep.join(['Earth', '6371', '5973.6']),
-            sep.join(['Moon', '1737', '73.5']),
-            sep.join(['Mars', '3390', '641.85'])]
+def sample_input(sep=" ", with_headers=False):
+    headers = sep.join(["Planet", "Radius", "Mass"])
+    rows = [
+        sep.join(["Sun", "696000", "1.9891e9"]),
+        sep.join(["Earth", "6371", "5973.6"]),
+        sep.join(["Moon", "1737", "73.5"]),
+        sep.join(["Mars", "3390", "641.85"]),
+    ]
     all_rows = ([headers] + rows) if with_headers else rows
     table = "\n".join(all_rows)
     return table
 
 
 def run_and_capture_stdout(cmd, input=None):
-    x = subprocess.Popen(cmd,
-                         stdin=subprocess.PIPE,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
+    x = subprocess.Popen(
+        cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     input_buf = input.encode() if input else None
     out, err = x.communicate(input=input_buf)
     out = out.decode("utf-8")
@@ -87,9 +100,13 @@ def run_and_capture_stdout(cmd, input=None):
 class TemporaryTextFile(object):
     def __init__(self):
         self.tmpfile = None
+
     def __enter__(self):
-        self.tmpfile = tempfile.NamedTemporaryFile("w+", prefix="tabulate-test-tmp-", delete=False)
+        self.tmpfile = tempfile.NamedTemporaryFile(
+            "w+", prefix="tabulate-test-tmp-", delete=False
+        )
         return self.tmpfile
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.tmpfile:
             self.tmpfile.close()
@@ -101,8 +118,8 @@ def test_script_from_stdin_to_stdout():
     cmd = [sys.executable, "tabulate.py"]
     out = run_and_capture_stdout(cmd, input=sample_input())
     expected = SAMPLE_SIMPLE_FORMAT
-    print("got:     ",repr(out))
-    print("expected:",repr(expected))
+    print("got:     ", repr(out))
+    print("expected:", repr(expected))
     assert_equal(out.splitlines(), expected.splitlines())
 
 
@@ -114,8 +131,8 @@ def test_script_from_file_to_stdout():
         cmd = [sys.executable, "tabulate.py", tmpfile.name]
         out = run_and_capture_stdout(cmd)
         expected = SAMPLE_SIMPLE_FORMAT
-        print("got:     ",repr(out))
-        print("expected:",repr(expected))
+        print("got:     ", repr(out))
+        print("expected:", repr(expected))
         assert_equal(out.splitlines(), expected.splitlines())
 
 
@@ -125,7 +142,13 @@ def test_script_from_file_to_file():
         with TemporaryTextFile() as output_file:
             input_file.write(sample_input())
             input_file.seek(0)
-            cmd = [sys.executable, "tabulate.py", "-o", output_file.name, input_file.name]
+            cmd = [
+                sys.executable,
+                "tabulate.py",
+                "-o",
+                output_file.name,
+                input_file.name,
+            ]
             out = run_and_capture_stdout(cmd)
             # check that nothing is printed to stdout
             expected = ""
@@ -149,8 +172,8 @@ def test_script_header_option():
         out = run_and_capture_stdout(cmd, input=raw_table)
         expected = SAMPLE_SIMPLE_FORMAT_WITH_HEADERS
         print(out)
-        print("got:     ",repr(out))
-        print("expected:",repr(expected))
+        print("got:     ", repr(out))
+        print("expected:", repr(expected))
         assert_equal(out.splitlines(), expected.splitlines())
 
 
@@ -161,8 +184,8 @@ def test_script_sep_option():
         raw_table = sample_input(sep=",")
         out = run_and_capture_stdout(cmd, input=raw_table)
         expected = SAMPLE_SIMPLE_FORMAT
-        print("got:     ",repr(out))
-        print("expected:",repr(expected))
+        print("got:     ", repr(out))
+        print("expected:", repr(expected))
         assert_equal(out.splitlines(), expected.splitlines())
 
 
@@ -173,8 +196,8 @@ def test_script_floatfmt_option():
         raw_table = sample_input()
         out = run_and_capture_stdout(cmd, input=raw_table)
         expected = SAMPLE_GRID_FORMAT_WITH_DOT1E_FLOATS
-        print("got:     ",repr(out))
-        print("expected:",repr(expected))
+        print("got:     ", repr(out))
+        print("expected:", repr(expected))
         assert_equal(out.splitlines(), expected.splitlines())
 
 
@@ -186,6 +209,6 @@ def test_script_format_option():
         out = run_and_capture_stdout(cmd, input=raw_table)
         expected = SAMPLE_GRID_FORMAT_WITH_HEADERS
         print(out)
-        print("got:     ",repr(out))
-        print("expected:",repr(expected))
+        print("got:     ", repr(out))
+        print("expected:", repr(expected))
         assert_equal(out.splitlines(), expected.splitlines())

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -10,97 +10,97 @@ from common import assert_equal, assert_in, assert_raises, SkipTest
 
 def test_iterable_of_iterables():
     "Input: an interable of iterables."
-    ii = iter(map(lambda x: iter(x), [range(5), range(5,0,-1)]))
+    ii = iter(map(lambda x: iter(x), [range(5), range(5, 0, -1)]))
     expected = "\n".join(
-        ['-  -  -  -  -',
-         '0  1  2  3  4',
-         '5  4  3  2  1',
-         '-  -  -  -  -'])
-    result   = tabulate(ii)
+        ["-  -  -  -  -", "0  1  2  3  4", "5  4  3  2  1", "-  -  -  -  -"]
+    )
+    result = tabulate(ii)
     assert_equal(expected, result)
 
 
 def test_iterable_of_iterables_headers():
     "Input: an interable of iterables with headers."
-    ii = iter(map(lambda x: iter(x), [range(5), range(5,0,-1)]))
+    ii = iter(map(lambda x: iter(x), [range(5), range(5, 0, -1)]))
     expected = "\n".join(
-        ['  a    b    c    d    e',
-         '---  ---  ---  ---  ---',
-         '  0    1    2    3    4',
-         '  5    4    3    2    1'])
-    result   = tabulate(ii, "abcde")
+        [
+            "  a    b    c    d    e",
+            "---  ---  ---  ---  ---",
+            "  0    1    2    3    4",
+            "  5    4    3    2    1",
+        ]
+    )
+    result = tabulate(ii, "abcde")
     assert_equal(expected, result)
 
 
 def test_iterable_of_iterables_firstrow():
     "Input: an interable of iterables with the first row as headers"
-    ii = iter(map(lambda x: iter(x), ["abcde", range(5), range(5,0,-1)]))
+    ii = iter(map(lambda x: iter(x), ["abcde", range(5), range(5, 0, -1)]))
     expected = "\n".join(
-        ['  a    b    c    d    e',
-         '---  ---  ---  ---  ---',
-         '  0    1    2    3    4',
-         '  5    4    3    2    1'])
-    result   = tabulate(ii, "firstrow")
+        [
+            "  a    b    c    d    e",
+            "---  ---  ---  ---  ---",
+            "  0    1    2    3    4",
+            "  5    4    3    2    1",
+        ]
+    )
+    result = tabulate(ii, "firstrow")
     assert_equal(expected, result)
 
 
 def test_list_of_lists():
     "Input: a list of lists with headers."
-    ll = [["a","one",1],["b","two",None]]
-    expected = "\n".join([
-        '    string      number',
-        '--  --------  --------',
-        'a   one              1',
-        'b   two'])
-    result   = tabulate(ll, headers=["string","number"])
+    ll = [["a", "one", 1], ["b", "two", None]]
+    expected = "\n".join(
+        [
+            "    string      number",
+            "--  --------  --------",
+            "a   one              1",
+            "b   two",
+        ]
+    )
+    result = tabulate(ll, headers=["string", "number"])
     assert_equal(expected, result)
 
 
 def test_list_of_lists_firstrow():
     "Input: a list of lists with the first row as headers."
-    ll = [["string","number"],["a","one",1],["b","two",None]]
-    expected = "\n".join([
-        '    string      number',
-        '--  --------  --------',
-        'a   one              1',
-        'b   two'])
-    result   = tabulate(ll, headers="firstrow")
+    ll = [["string", "number"], ["a", "one", 1], ["b", "two", None]]
+    expected = "\n".join(
+        [
+            "    string      number",
+            "--  --------  --------",
+            "a   one              1",
+            "b   two",
+        ]
+    )
+    result = tabulate(ll, headers="firstrow")
     assert_equal(expected, result)
 
 
 def test_list_of_lists_keys():
     "Input: a list of lists with column indices as headers."
-    ll = [["a","one",1],["b","two",None]]
-    expected = "\n".join([
-        '0    1      2',
-        '---  ---  ---',
-        'a    one    1',
-        'b    two'])
-    result   = tabulate(ll, headers="keys")
+    ll = [["a", "one", 1], ["b", "two", None]]
+    expected = "\n".join(
+        ["0    1      2", "---  ---  ---", "a    one    1", "b    two"]
+    )
+    result = tabulate(ll, headers="keys")
     assert_equal(expected, result)
 
 
 def test_dict_like():
     "Input: a dict of iterables with keys as headers."
     # columns should be padded with None, keys should be used as headers
-    dd = {"a": range(3), "b": range(101,105)}
+    dd = {"a": range(3), "b": range(101, 105)}
     # keys' order (hence columns' order) is not deterministic in Python 3
     # => we have to consider both possible results as valid
-    expected1 = "\n".join([
-        '  a    b',
-        '---  ---',
-        '  0  101',
-        '  1  102',
-        '  2  103',
-        '     104'])
-    expected2 = "\n".join([
-        '  b    a',
-        '---  ---',
-        '101    0',
-        '102    1',
-        '103    2',
-        '104'])
-    result    = tabulate(dd, "keys")
+    expected1 = "\n".join(
+        ["  a    b", "---  ---", "  0  101", "  1  102", "  2  103", "     104"]
+    )
+    expected2 = "\n".join(
+        ["  b    a", "---  ---", "101    0", "102    1", "103    2", "104"]
+    )
+    result = tabulate(dd, "keys")
     print("Keys' order: %s" % dd.keys())
     assert_in(result, [expected1, expected2])
 
@@ -109,183 +109,217 @@ def test_numpy_2d():
     "Input: a 2D NumPy array with headers."
     try:
         import numpy
-        na = (numpy.arange(1,10, dtype=numpy.float32).reshape((3,3))**3)*0.5
-        expected = "\n".join([
-            '    a      b      c',
-            '-----  -----  -----',
-            '  0.5    4     13.5',
-            ' 32     62.5  108',
-            '171.5  256    364.5'])
-        result   = tabulate(na, ["a", "b", "c"])
+
+        na = (numpy.arange(1, 10, dtype=numpy.float32).reshape((3, 3)) ** 3) * 0.5
+        expected = "\n".join(
+            [
+                "    a      b      c",
+                "-----  -----  -----",
+                "  0.5    4     13.5",
+                " 32     62.5  108",
+                "171.5  256    364.5",
+            ]
+        )
+        result = tabulate(na, ["a", "b", "c"])
         assert_equal(expected, result)
     except ImportError:
         print("test_numpy_2d is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_numpy_2d_firstrow():
     "Input: a 2D NumPy array with the first row as headers."
     try:
         import numpy
-        na = (numpy.arange(1,10, dtype=numpy.int32).reshape((3,3))**3)
-        expected = "\n".join([
-            '  1    8    27',
-            '---  ---  ----',
-            ' 64  125   216',
-            '343  512   729'])
-        result   = tabulate(na, headers="firstrow")
+
+        na = numpy.arange(1, 10, dtype=numpy.int32).reshape((3, 3)) ** 3
+        expected = "\n".join(
+            ["  1    8    27", "---  ---  ----", " 64  125   216", "343  512   729"]
+        )
+        result = tabulate(na, headers="firstrow")
         assert_equal(expected, result)
     except ImportError:
         print("test_numpy_2d_firstrow is skipped")
-        raise SkipTest()   # this test is optional
-
+        raise SkipTest()  # this test is optional
 
 
 def test_numpy_2d_keys():
     "Input: a 2D NumPy array with column indices as headers."
     try:
         import numpy
-        na = (numpy.arange(1,10, dtype=numpy.float32).reshape((3,3))**3)*0.5
-        expected = "\n".join([
-            '    0      1      2',
-            '-----  -----  -----',
-            '  0.5    4     13.5',
-            ' 32     62.5  108',
-            '171.5  256    364.5'])
-        result   = tabulate(na, headers="keys")
+
+        na = (numpy.arange(1, 10, dtype=numpy.float32).reshape((3, 3)) ** 3) * 0.5
+        expected = "\n".join(
+            [
+                "    0      1      2",
+                "-----  -----  -----",
+                "  0.5    4     13.5",
+                " 32     62.5  108",
+                "171.5  256    364.5",
+            ]
+        )
+        result = tabulate(na, headers="keys")
         assert_equal(expected, result)
     except ImportError:
         print("test_numpy_2d_keys is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_numpy_record_array():
     "Input: a 2D NumPy record array without header."
     try:
         import numpy
-        na = numpy.asarray([("Alice", 23, 169.5),
-                            ("Bob", 27, 175.0)],
-                           dtype={"names":["name","age","height"],
-                                  "formats":["a32","uint8","float32"]})
-        expected = "\n".join([
-            "-----  --  -----",
-            "Alice  23  169.5",
-            "Bob    27  175",
-            "-----  --  -----" ])
-        result   = tabulate(na)
+
+        na = numpy.asarray(
+            [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
+            dtype={
+                "names": ["name", "age", "height"],
+                "formats": ["a32", "uint8", "float32"],
+            },
+        )
+        expected = "\n".join(
+            [
+                "-----  --  -----",
+                "Alice  23  169.5",
+                "Bob    27  175",
+                "-----  --  -----",
+            ]
+        )
+        result = tabulate(na)
         assert_equal(expected, result)
     except ImportError:
         print("test_numpy_2d_keys is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_numpy_record_array_keys():
     "Input: a 2D NumPy record array with column names as headers."
     try:
         import numpy
-        na = numpy.asarray([("Alice", 23, 169.5),
-                            ("Bob", 27, 175.0)],
-                           dtype={"names":["name","age","height"],
-                                  "formats":["a32","uint8","float32"]})
-        expected = "\n".join([
-            "name      age    height",
-            "------  -----  --------",
-            "Alice      23     169.5",
-            "Bob        27     175"  ])
-        result   = tabulate(na, headers="keys")
+
+        na = numpy.asarray(
+            [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
+            dtype={
+                "names": ["name", "age", "height"],
+                "formats": ["a32", "uint8", "float32"],
+            },
+        )
+        expected = "\n".join(
+            [
+                "name      age    height",
+                "------  -----  --------",
+                "Alice      23     169.5",
+                "Bob        27     175",
+            ]
+        )
+        result = tabulate(na, headers="keys")
         assert_equal(expected, result)
     except ImportError:
         print("test_numpy_2d_keys is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_numpy_record_array_headers():
     "Input: a 2D NumPy record array with user-supplied headers."
     try:
         import numpy
-        na = numpy.asarray([("Alice", 23, 169.5),
-                            ("Bob", 27, 175.0)],
-                           dtype={"names":["name","age","height"],
-                                  "formats":["a32","uint8","float32"]})
-        expected = "\n".join([
-            "person      years     cm",
-            "--------  -------  -----",
-            "Alice          23  169.5",
-            "Bob            27  175" ])
-        result   = tabulate(na, headers=["person", "years", "cm"])
+
+        na = numpy.asarray(
+            [("Alice", 23, 169.5), ("Bob", 27, 175.0)],
+            dtype={
+                "names": ["name", "age", "height"],
+                "formats": ["a32", "uint8", "float32"],
+            },
+        )
+        expected = "\n".join(
+            [
+                "person      years     cm",
+                "--------  -------  -----",
+                "Alice          23  169.5",
+                "Bob            27  175",
+            ]
+        )
+        result = tabulate(na, headers=["person", "years", "cm"])
         assert_equal(expected, result)
     except ImportError:
         print("test_numpy_2d_keys is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_pandas():
     "Input: a Pandas DataFrame."
     try:
         import pandas
-        df = pandas.DataFrame([["one",1],["two",None]], index=["a","b"])
-        expected = "\n".join([
-            '    string      number',
-            '--  --------  --------',
-            'a   one              1',
-            'b   two            nan'])
-        result   = tabulate(df, headers=["string", "number"])
+
+        df = pandas.DataFrame([["one", 1], ["two", None]], index=["a", "b"])
+        expected = "\n".join(
+            [
+                "    string      number",
+                "--  --------  --------",
+                "a   one              1",
+                "b   two            nan",
+            ]
+        )
+        result = tabulate(df, headers=["string", "number"])
         assert_equal(expected, result)
     except ImportError:
         print("test_pandas is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_pandas_firstrow():
     "Input: a Pandas DataFrame with the first row as headers."
     try:
         import pandas
-        df = pandas.DataFrame([["one",1],["two",None]],
-                              columns=["string","number"],
-                              index=["a","b"])
-        expected = "\n".join([
-            'a    one      1.0',
-            '---  -----  -----',
-            'b    two      nan'])
-        result   = tabulate(df, headers="firstrow")
+
+        df = pandas.DataFrame(
+            [["one", 1], ["two", None]], columns=["string", "number"], index=["a", "b"]
+        )
+        expected = "\n".join(
+            ["a    one      1.0", "---  -----  -----", "b    two      nan"]
+        )
+        result = tabulate(df, headers="firstrow")
         assert_equal(expected, result)
     except ImportError:
         print("test_pandas_firstrow is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_pandas_keys():
     "Input: a Pandas DataFrame with keys as headers."
     try:
         import pandas
-        df = pandas.DataFrame([["one",1],["two",None]],
-                              columns=["string","number"],
-                              index=["a","b"])
+
+        df = pandas.DataFrame(
+            [["one", 1], ["two", None]], columns=["string", "number"], index=["a", "b"]
+        )
         expected = "\n".join(
-            ['    string      number',
-             '--  --------  --------',
-             'a   one              1',
-             'b   two            nan'])
-        result   = tabulate(df, headers="keys")
+            [
+                "    string      number",
+                "--  --------  --------",
+                "a   one              1",
+                "b   two            nan",
+            ]
+        )
+        result = tabulate(df, headers="keys")
         assert_equal(expected, result)
     except ImportError:
         print("test_pandas_keys is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_sqlite3():
     "Input: an sqlite3 cursor"
     try:
         import sqlite3
-        conn = sqlite3.connect(':memory:')
+
+        conn = sqlite3.connect(":memory:")
         cursor = conn.cursor()
-        cursor.execute('CREATE TABLE people (name, age, height)')
-        for values in [
-            ("Alice", 23, 169.5),
-            ("Bob", 27, 175.0)]:
-            cursor.execute('INSERT INTO people VALUES (?, ?, ?)', values)
-        cursor.execute('SELECT name, age, height FROM people ORDER BY name')
-        result   = tabulate(cursor, headers=["whom", "how old", "how tall"])
+        cursor.execute("CREATE TABLE people (name, age, height)")
+        for values in [("Alice", 23, 169.5), ("Bob", 27, 175.0)]:
+            cursor.execute("INSERT INTO people VALUES (?, ?, ?)", values)
+        cursor.execute("SELECT name, age, height FROM people ORDER BY name")
+        result = tabulate(cursor, headers=["whom", "how old", "how tall"])
         expected = """\
 whom      how old    how tall
 ------  ---------  ----------
@@ -294,22 +328,23 @@ Bob            27       175"""
         assert_equal(expected, result)
     except ImportError:
         print("test_sqlite3 is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_sqlite3_keys():
     "Input: an sqlite3 cursor with keys as headers"
     try:
         import sqlite3
-        conn = sqlite3.connect(':memory:')
+
+        conn = sqlite3.connect(":memory:")
         cursor = conn.cursor()
-        cursor.execute('CREATE TABLE people (name, age, height)')
-        for values in [
-            ("Alice", 23, 169.5),
-            ("Bob", 27, 175.0)]:
-            cursor.execute('INSERT INTO people VALUES (?, ?, ?)', values)
-        cursor.execute('SELECT name "whom", age "how old", height "how tall" FROM people ORDER BY name')
-        result   = tabulate(cursor, headers="keys")
+        cursor.execute("CREATE TABLE people (name, age, height)")
+        for values in [("Alice", 23, 169.5), ("Bob", 27, 175.0)]:
+            cursor.execute("INSERT INTO people VALUES (?, ?, ?)", values)
+        cursor.execute(
+            'SELECT name "whom", age "how old", height "how tall" FROM people ORDER BY name'
+        )
+        result = tabulate(cursor, headers="keys")
         expected = """\
 whom      how old    how tall
 ------  ---------  ----------
@@ -318,19 +353,16 @@ Bob            27       175"""
         assert_equal(expected, result)
     except ImportError:
         print("test_sqlite3_keys is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_list_of_namedtuples():
     "Input: a list of named tuples with field names as headers."
     from collections import namedtuple
-    NT = namedtuple("NT", ['foo', 'bar'])
-    lt = [NT(1,2), NT(3,4)]
-    expected = "\n".join([
-        '-  -',
-        '1  2',
-        '3  4',
-        '-  -'])
+
+    NT = namedtuple("NT", ["foo", "bar"])
+    lt = [NT(1, 2), NT(3, 4)]
+    expected = "\n".join(["-  -", "1  2", "3  4", "-  -"])
     result = tabulate(lt)
     assert_equal(expected, result)
 
@@ -338,76 +370,64 @@ def test_list_of_namedtuples():
 def test_list_of_namedtuples_keys():
     "Input: a list of named tuples with field names as headers."
     from collections import namedtuple
-    NT = namedtuple("NT", ['foo', 'bar'])
-    lt = [NT(1,2), NT(3,4)]
-    expected = "\n".join([
-        '  foo    bar',
-        '-----  -----',
-        '    1      2',
-        '    3      4'])
+
+    NT = namedtuple("NT", ["foo", "bar"])
+    lt = [NT(1, 2), NT(3, 4)]
+    expected = "\n".join(
+        ["  foo    bar", "-----  -----", "    1      2", "    3      4"]
+    )
     result = tabulate(lt, headers="keys")
     assert_equal(expected, result)
 
 
 def test_list_of_dicts():
     "Input: a list of dictionaries."
-    lod = [{'foo' : 1, 'bar' : 2}, {'foo' : 3, 'bar' : 4}]
-    expected1 = "\n".join([
-        '-  -',
-        '1  2',
-        '3  4',
-        '-  -'])
-    expected2 = "\n".join([
-        '-  -',
-        '2  1',
-        '4  3',
-        '-  -'])
+    lod = [{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}]
+    expected1 = "\n".join(["-  -", "1  2", "3  4", "-  -"])
+    expected2 = "\n".join(["-  -", "2  1", "4  3", "-  -"])
     result = tabulate(lod)
     assert_in(result, [expected1, expected2])
 
 
 def test_list_of_dicts_keys():
     "Input: a list of dictionaries, with keys as headers."
-    lod = [{'foo' : 1, 'bar' : 2}, {'foo' : 3, 'bar' : 4}]
-    expected1 = "\n".join([
-        '  foo    bar',
-        '-----  -----',
-        '    1      2',
-        '    3      4'])
-    expected2 = "\n".join([
-        '  bar    foo',
-        '-----  -----',
-        '    2      1',
-        '    4      3'])
+    lod = [{"foo": 1, "bar": 2}, {"foo": 3, "bar": 4}]
+    expected1 = "\n".join(
+        ["  foo    bar", "-----  -----", "    1      2", "    3      4"]
+    )
+    expected2 = "\n".join(
+        ["  bar    foo", "-----  -----", "    2      1", "    4      3"]
+    )
     result = tabulate(lod, headers="keys")
     assert_in(result, [expected1, expected2])
 
 
 def test_list_of_dicts_with_missing_keys():
     "Input: a list of dictionaries, with missing keys."
-    lod = [{"foo": 1}, {"bar": 2}, {"foo":4, "baz": 3}]
-    expected = "\n".join([
-        '  foo    bar    baz',
-        '-----  -----  -----',
-        '    1',
-        '           2',
-        '    4             3'])
+    lod = [{"foo": 1}, {"bar": 2}, {"foo": 4, "baz": 3}]
+    expected = "\n".join(
+        [
+            "  foo    bar    baz",
+            "-----  -----  -----",
+            "    1",
+            "           2",
+            "    4             3",
+        ]
+    )
     result = tabulate(lod, headers="keys")
     assert_equal(expected, result)
 
 
 def test_list_of_dicts_firstrow():
     "Input: a list of dictionaries, with the first dict as headers."
-    lod = [{'foo' : "FOO", 'bar' : "BAR"}, {'foo' : 3, 'bar': 4, 'baz': 5}]
+    lod = [{"foo": "FOO", "bar": "BAR"}, {"foo": 3, "bar": 4, "baz": 5}]
     # if some key is missing in the first dict, use the key name instead
-    expected1 = "\n".join([
-        '  FOO    BAR    baz',
-        '-----  -----  -----',
-        '    3      4      5'])
-    expected2 = "\n".join([
-        '  BAR    FOO    baz',
-        '-----  -----  -----',
-        '    4      3      5'])
+    expected1 = "\n".join(
+        ["  FOO    BAR    baz", "-----  -----  -----", "    3      4      5"]
+    )
+    expected2 = "\n".join(
+        ["  BAR    FOO    baz", "-----  -----  -----", "    4      3      5"]
+    )
     result = tabulate(lod, headers="firstrow")
     assert_in(result, [expected1, expected2])
 
@@ -416,14 +436,12 @@ def test_list_of_dicts_with_dict_of_headers():
     "Input: a dict of user headers for a list of dicts (issue #23)"
     table = [{"letters": "ABCDE", "digits": 12345}]
     headers = {"digits": "DIGITS", "letters": "LETTERS"}
-    expected1 = "\n".join([
-        '  DIGITS  LETTERS',
-        '--------  ---------',
-        '   12345  ABCDE'])
-    expected2 = "\n".join([
-        'LETTERS      DIGITS',
-        '---------  --------',
-        'ABCDE         12345'])
+    expected1 = "\n".join(
+        ["  DIGITS  LETTERS", "--------  ---------", "   12345  ABCDE"]
+    )
+    expected2 = "\n".join(
+        ["LETTERS      DIGITS", "---------  --------", "ABCDE         12345"]
+    )
     result = tabulate(table, headers=headers)
     assert_in(result, [expected1, expected2])
 
@@ -439,12 +457,9 @@ def test_list_of_dicts_with_list_of_headers():
 def test_py27orlater_list_of_ordereddicts():
     "Input: a list of OrderedDicts."
     from collections import OrderedDict
-    od = OrderedDict([('b', 1), ('a', 2)])
+
+    od = OrderedDict([("b", 1), ("a", 2)])
     lod = [od, od]
-    expected = "\n".join([
-        '  b    a',
-        '---  ---',
-        '  1    2',
-        '  1    2'])
+    expected = "\n".join(["  b    a", "---  ---", "  1    2", "  1    2"])
     result = tabulate(lod, headers="keys")
     assert_equal(expected, result)

--- a/test/test_internal.py
+++ b/test/test_internal.py
@@ -5,7 +5,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 import tabulate as T
-from common import assert_equal, assert_in, assert_raises, SkipTest
+from common import assert_equal
 
 
 def test_multiline_width():
@@ -21,20 +21,21 @@ def test_align_column_decimal():
     column = ["12.345", "-1234.5", "1.23", "1234.5", "1e+234", "1.0e234"]
     output = T._align_column(column, "decimal")
     expected = [
-            '   12.345  ',
-            '-1234.5    ',
-            '    1.23   ',
-            ' 1234.5    ',
-            '    1e+234 ',
-            '    1.0e234']
+        "   12.345  ",
+        "-1234.5    ",
+        "    1.23   ",
+        " 1234.5    ",
+        "    1e+234 ",
+        "    1.0e234",
+    ]
     assert_equal(output, expected)
 
 
 def test_align_column_none():
     "Internal: _align_column(..., None)"
-    column = ['123.4', '56.7890']
+    column = ["123.4", "56.7890"]
     output = T._align_column(column, None)
-    expected = ['123.4', '56.7890']
+    expected = ["123.4", "56.7890"]
     assert_equal(output, expected)
 
 
@@ -42,9 +43,5 @@ def test_align_column_multiline():
     "Internal: _align_column(..., is_multiline=True)"
     column = ["1", "123", "12345\n6"]
     output = T._align_column(column, "center", is_multiline=True)
-    expected = [
-            "  1  ",
-            " 123 ",
-            "12345" + "\n" +
-            "  6  "]
+    expected = ["  1  ", " 123 ", "12345" + "\n" + "  6  "]
     assert_equal(output, expected)

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -19,17 +19,16 @@ _test_table_headers = ["strings", "numbers"]
 
 def test_plain():
     "Output: plain with headers"
-    expected = "\n".join(['strings      numbers',
-                          'spam         41.9999',
-                          'eggs        451',])
+    expected = "\n".join(
+        ["strings      numbers", "spam         41.9999", "eggs        451"]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="plain")
     assert_equal(expected, result)
 
 
 def test_plain_headerless():
     "Output: plain without headers"
-    expected = "\n".join(['spam   41.9999',
-                          'eggs  451',])
+    expected = "\n".join(["spam   41.9999", "eggs  451"])
     result = tabulate(_test_table, tablefmt="plain")
     assert_equal(expected, result)
 
@@ -37,12 +36,9 @@ def test_plain_headerless():
 def test_plain_multiline_headerless():
     "Output: plain with multiline cells without headers"
     table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
-    expected = "\n".join([
-        "foo bar    hello",
-        "  baz",
-        "  bau",
-        "         multiline",
-        "           world"])
+    expected = "\n".join(
+        ["foo bar    hello", "  baz", "  bau", "         multiline", "           world"]
+    )
     result = tabulate(table, stralign="center", tablefmt="plain")
     assert_equal(expected, result)
 
@@ -51,11 +47,14 @@ def test_plain_multiline():
     "Output: plain with multiline cells with headers"
     table = [[2, "foo\nbar"]]
     headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
-    expected = "\n".join([
-        "       more  more spam",
-        "  spam \x1b[31meggs\x1b[0m  & eggs",
-        "          2  foo",
-        "             bar"])
+    expected = "\n".join(
+        [
+            "       more  more spam",
+            "  spam \x1b[31meggs\x1b[0m  & eggs",
+            "          2  foo",
+            "             bar",
+        ]
+    )
     result = tabulate(table, headers, tablefmt="plain")
     assert_equal(expected, result)
 
@@ -63,66 +62,67 @@ def test_plain_multiline():
 def test_plain_multiline_with_empty_cells():
     "Output: plain with multiline cells and empty cells with headers"
     table = [
-        ['hdr', 'data', 'fold'],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
+        ["hdr", "data", "fold"],
+        ["1", "", ""],
+        ["2", "very long data", "fold\nthis"],
     ]
-    expected = "\n".join([
-        "  hdr  data            fold",
-        "    1",
-        "    2  very long data  fold",
-        "                       this"])
+    expected = "\n".join(
+        [
+            "  hdr  data            fold",
+            "    1",
+            "    2  very long data  fold",
+            "                       this",
+        ]
+    )
     result = tabulate(table, headers="firstrow", tablefmt="plain")
     assert_equal(expected, result)
 
 
 def test_plain_multiline_with_empty_cells_headerless():
     "Output: plain with multiline cells and empty cells without headers"
-    table = [
-        ['0', '', ''],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
-    ]
-    expected = "\n".join([
-        "0",
-        "1",
-        "2  very long data  fold",
-        "                   this"])
+    table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+    expected = "\n".join(
+        ["0", "1", "2  very long data  fold", "                   this"]
+    )
     result = tabulate(table, tablefmt="plain")
     assert_equal(expected, result)
 
 
 def test_simple():
     "Output: simple with headers"
-    expected = "\n".join(['strings      numbers',
-                          '---------  ---------',
-                          'spam         41.9999',
-                          'eggs        451',])
+    expected = "\n".join(
+        [
+            "strings      numbers",
+            "---------  ---------",
+            "spam         41.9999",
+            "eggs        451",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="simple")
     assert_equal(expected, result)
 
 
-def test_simple_multiline():
+def test_simple_multiline_2():
     "Output: simple with multiline cells"
-    expected = "\n".join([
-        " key     value",
-        "-----  ---------",
-        " foo      bar",
-        "spam   multiline",
-        "         world",
-    ])
+    expected = "\n".join(
+        [
+            " key     value",
+            "-----  ---------",
+            " foo      bar",
+            "spam   multiline",
+            "         world",
+        ]
+    )
     table = [["key", "value"], ["foo", "bar"], ["spam", "multiline\nworld"]]
-    result = tabulate(table, headers='firstrow', stralign="center",
-                      tablefmt="simple")
+    result = tabulate(table, headers="firstrow", stralign="center", tablefmt="simple")
     assert_equal(expected, result)
 
 
 def test_simple_headerless():
     "Output: simple without headers"
-    expected = "\n".join(['----  --------',
-                          'spam   41.9999',
-                          'eggs  451',
-                          '----  --------',])
+    expected = "\n".join(
+        ["----  --------", "spam   41.9999", "eggs  451", "----  --------"]
+    )
     result = tabulate(_test_table, tablefmt="simple")
     assert_equal(expected, result)
 
@@ -130,14 +130,17 @@ def test_simple_headerless():
 def test_simple_multiline_headerless():
     "Output: simple with multiline cells without headers"
     table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
-    expected = "\n".join([
-        "-------  ---------",
-        "foo bar    hello",
-        "  baz",
-        "  bau",
-        "         multiline",
-        "           world",
-        "-------  ---------",])
+    expected = "\n".join(
+        [
+            "-------  ---------",
+            "foo bar    hello",
+            "  baz",
+            "  bau",
+            "         multiline",
+            "           world",
+            "-------  ---------",
+        ]
+    )
     result = tabulate(table, stralign="center", tablefmt="simple")
     assert_equal(expected, result)
 
@@ -146,12 +149,15 @@ def test_simple_multiline():
     "Output: simple with multiline cells with headers"
     table = [[2, "foo\nbar"]]
     headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
-    expected = "\n".join([
-        "       more  more spam",
-        "  spam \x1b[31meggs\x1b[0m  & eggs",
-        "-----------  -----------",
-        "          2  foo",
-        "             bar"])
+    expected = "\n".join(
+        [
+            "       more  more spam",
+            "  spam \x1b[31meggs\x1b[0m  & eggs",
+            "-----------  -----------",
+            "          2  foo",
+            "             bar",
+        ]
+    )
     result = tabulate(table, headers, tablefmt="simple")
     assert_equal(expected, result)
 
@@ -159,57 +165,67 @@ def test_simple_multiline():
 def test_simple_multiline_with_empty_cells():
     "Output: simple with multiline cells and empty cells with headers"
     table = [
-        ['hdr', 'data', 'fold'],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
+        ["hdr", "data", "fold"],
+        ["1", "", ""],
+        ["2", "very long data", "fold\nthis"],
     ]
-    expected = "\n".join([
-        "  hdr  data            fold",
-        "-----  --------------  ------",
-        "    1",
-        "    2  very long data  fold",
-        "                       this"])
+    expected = "\n".join(
+        [
+            "  hdr  data            fold",
+            "-----  --------------  ------",
+            "    1",
+            "    2  very long data  fold",
+            "                       this",
+        ]
+    )
     result = tabulate(table, headers="firstrow", tablefmt="simple")
     assert_equal(expected, result)
 
 
 def test_simple_multiline_with_empty_cells_headerless():
     "Output: simple with multiline cells and empty cells without headers"
-    table = [
-        ['0', '', ''],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
-    ]
-    expected = "\n".join([
-        "-  --------------  ----",
-        "0",
-        "1",
-        "2  very long data  fold",
-        "                   this",
-        "-  --------------  ----",])
+    table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+    expected = "\n".join(
+        [
+            "-  --------------  ----",
+            "0",
+            "1",
+            "2  very long data  fold",
+            "                   this",
+            "-  --------------  ----",
+        ]
+    )
     result = tabulate(table, tablefmt="simple")
     assert_equal(expected, result)
 
 
 def test_github():
     "Output: github with headers"
-    expected = '\n'.join(['| strings   |   numbers |',
-                          '|-----------|-----------|',
-                          '| spam      |   41.9999 |',
-                          '| eggs      |  451      |',])
+    expected = "\n".join(
+        [
+            "| strings   |   numbers |",
+            "|-----------|-----------|",
+            "| spam      |   41.9999 |",
+            "| eggs      |  451      |",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="github")
     assert_equal(expected, result)
 
 
 def test_grid():
     "Output: grid with headers"
-    expected = '\n'.join(['+-----------+-----------+',
-                          '| strings   |   numbers |',
-                          '+===========+===========+',
-                          '| spam      |   41.9999 |',
-                          '+-----------+-----------+',
-                          '| eggs      |  451      |',
-                          '+-----------+-----------+',])
+    expected = "\n".join(
+        [
+            "+-----------+-----------+",
+            "| strings   |   numbers |",
+            "+===========+===========+",
+            "| spam      |   41.9999 |",
+            "+-----------+-----------+",
+            "| eggs      |  451      |",
+            "+-----------+-----------+",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="grid")
     assert_equal(expected, result)
 
@@ -217,30 +233,38 @@ def test_grid():
 def test_grid_wide_characters():
     "Output: grid with wide characters in headers"
     try:
-        import wcwidth
+        import wcwidth  # noqa
     except ImportError:
         print("test_grid_wide_characters is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
     headers = list(_test_table_headers)
-    headers[1] = '配列'
-    expected = '\n'.join(['+-----------+----------+',
-                          '| strings   |     配列 |',
-                          '+===========+==========+',
-                          '| spam      |  41.9999 |',
-                          '+-----------+----------+',
-                          '| eggs      | 451      |',
-                          '+-----------+----------+',])
+    headers[1] = "配列"
+    expected = "\n".join(
+        [
+            "+-----------+----------+",
+            "| strings   |     配列 |",
+            "+===========+==========+",
+            "| spam      |  41.9999 |",
+            "+-----------+----------+",
+            "| eggs      | 451      |",
+            "+-----------+----------+",
+        ]
+    )
     result = tabulate(_test_table, headers, tablefmt="grid")
     assert_equal(expected, result)
 
 
 def test_grid_headerless():
     "Output: grid without headers"
-    expected = '\n'.join(['+------+----------+',
-                          '| spam |  41.9999 |',
-                          '+------+----------+',
-                          '| eggs | 451      |',
-                          '+------+----------+',])
+    expected = "\n".join(
+        [
+            "+------+----------+",
+            "| spam |  41.9999 |",
+            "+------+----------+",
+            "| eggs | 451      |",
+            "+------+----------+",
+        ]
+    )
     result = tabulate(_test_table, tablefmt="grid")
     assert_equal(expected, result)
 
@@ -248,15 +272,18 @@ def test_grid_headerless():
 def test_grid_multiline_headerless():
     "Output: grid with multiline cells without headers"
     table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
-    expected = "\n".join([
-        "+---------+-----------+",
-        "| foo bar |   hello   |",
-        "|   baz   |           |",
-        "|   bau   |           |",
-        "+---------+-----------+",
-        "|         | multiline |",
-        "|         |   world   |",
-        "+---------+-----------+"])
+    expected = "\n".join(
+        [
+            "+---------+-----------+",
+            "| foo bar |   hello   |",
+            "|   baz   |           |",
+            "|   bau   |           |",
+            "+---------+-----------+",
+            "|         | multiline |",
+            "|         |   world   |",
+            "+---------+-----------+",
+        ]
+    )
     result = tabulate(table, stralign="center", tablefmt="grid")
     assert_equal(expected, result)
 
@@ -265,14 +292,17 @@ def test_grid_multiline():
     "Output: grid with multiline cells with headers"
     table = [[2, "foo\nbar"]]
     headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
-    expected = "\n".join([
-        "+-------------+-------------+",
-        "|        more | more spam   |",
-        "|   spam \x1b[31meggs\x1b[0m | & eggs      |",
-        "+=============+=============+",
-        "|           2 | foo         |",
-        "|             | bar         |",
-        "+-------------+-------------+"])
+    expected = "\n".join(
+        [
+            "+-------------+-------------+",
+            "|        more | more spam   |",
+            "|   spam \x1b[31meggs\x1b[0m | & eggs      |",
+            "+=============+=============+",
+            "|           2 | foo         |",
+            "|             | bar         |",
+            "+-------------+-------------+",
+        ]
+    )
     result = tabulate(table, headers, tablefmt="grid")
     assert_equal(expected, result)
 
@@ -280,65 +310,73 @@ def test_grid_multiline():
 def test_grid_multiline_with_empty_cells():
     "Output: grid with multiline cells and empty cells with headers"
     table = [
-        ['hdr', 'data', 'fold'],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
+        ["hdr", "data", "fold"],
+        ["1", "", ""],
+        ["2", "very long data", "fold\nthis"],
     ]
-    expected = "\n".join([
-        "+-------+----------------+--------+",
-        "|   hdr | data           | fold   |",
-        "+=======+================+========+",
-        "|     1 |                |        |",
-        "+-------+----------------+--------+",
-        "|     2 | very long data | fold   |",
-        "|       |                | this   |",
-        "+-------+----------------+--------+"])
+    expected = "\n".join(
+        [
+            "+-------+----------------+--------+",
+            "|   hdr | data           | fold   |",
+            "+=======+================+========+",
+            "|     1 |                |        |",
+            "+-------+----------------+--------+",
+            "|     2 | very long data | fold   |",
+            "|       |                | this   |",
+            "+-------+----------------+--------+",
+        ]
+    )
     result = tabulate(table, headers="firstrow", tablefmt="grid")
     assert_equal(expected, result)
 
 
 def test_grid_multiline_with_empty_cells_headerless():
     "Output: grid with multiline cells and empty cells without headers"
-    table = [
-        ['0', '', ''],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
-    ]
-    expected = "\n".join([
-        "+---+----------------+------+",
-        "| 0 |                |      |",
-        "+---+----------------+------+",
-        "| 1 |                |      |",
-        "+---+----------------+------+",
-        "| 2 | very long data | fold |",
-        "|   |                | this |",
-        "+---+----------------+------+"])
+    table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+    expected = "\n".join(
+        [
+            "+---+----------------+------+",
+            "| 0 |                |      |",
+            "+---+----------------+------+",
+            "| 1 |                |      |",
+            "+---+----------------+------+",
+            "| 2 | very long data | fold |",
+            "|   |                | this |",
+            "+---+----------------+------+",
+        ]
+    )
     result = tabulate(table, tablefmt="grid")
     assert_equal(expected, result)
 
 
 def test_fancy_grid():
     "Output: fancy_grid with headers"
-    expected = '\n'.join([
-        '╒═══════════╤═══════════╕',
-        '│ strings   │   numbers │',
-        '╞═══════════╪═══════════╡',
-        '│ spam      │   41.9999 │',
-        '├───────────┼───────────┤',
-        '│ eggs      │  451      │',
-        '╘═══════════╧═══════════╛',])
+    expected = "\n".join(
+        [
+            "╒═══════════╤═══════════╕",
+            "│ strings   │   numbers │",
+            "╞═══════════╪═══════════╡",
+            "│ spam      │   41.9999 │",
+            "├───────────┼───────────┤",
+            "│ eggs      │  451      │",
+            "╘═══════════╧═══════════╛",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="fancy_grid")
     assert_equal(expected, result)
 
 
 def test_fancy_grid_headerless():
     "Output: fancy_grid without headers"
-    expected = '\n'.join([
-        '╒══════╤══════════╕',
-        '│ spam │  41.9999 │',
-        '├──────┼──────────┤',
-        '│ eggs │ 451      │',
-        '╘══════╧══════════╛',])
+    expected = "\n".join(
+        [
+            "╒══════╤══════════╕",
+            "│ spam │  41.9999 │",
+            "├──────┼──────────┤",
+            "│ eggs │ 451      │",
+            "╘══════╧══════════╛",
+        ]
+    )
     result = tabulate(_test_table, tablefmt="fancy_grid")
     assert_equal(expected, result)
 
@@ -346,15 +384,18 @@ def test_fancy_grid_headerless():
 def test_fancy_grid_multiline_headerless():
     "Output: fancy_grid with multiline cells without headers"
     table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
-    expected = "\n".join([
-        "╒═════════╤═══════════╕",
-        "│ foo bar │   hello   │",
-        "│   baz   │           │",
-        "│   bau   │           │",
-        "├─────────┼───────────┤",
-        "│         │ multiline │",
-        "│         │   world   │",
-        "╘═════════╧═══════════╛"])
+    expected = "\n".join(
+        [
+            "╒═════════╤═══════════╕",
+            "│ foo bar │   hello   │",
+            "│   baz   │           │",
+            "│   bau   │           │",
+            "├─────────┼───────────┤",
+            "│         │ multiline │",
+            "│         │   world   │",
+            "╘═════════╧═══════════╛",
+        ]
+    )
     result = tabulate(table, stralign="center", tablefmt="fancy_grid")
     assert_equal(expected, result)
 
@@ -363,14 +404,17 @@ def test_fancy_grid_multiline():
     "Output: fancy_grid with multiline cells with headers"
     table = [[2, "foo\nbar"]]
     headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
-    expected = "\n".join([
-        "╒═════════════╤═════════════╕",
-        "│        more │ more spam   │",
-        "│   spam \x1b[31meggs\x1b[0m │ & eggs      │",
-        "╞═════════════╪═════════════╡",
-        "│           2 │ foo         │",
-        "│             │ bar         │",
-        "╘═════════════╧═════════════╛"])
+    expected = "\n".join(
+        [
+            "╒═════════════╤═════════════╕",
+            "│        more │ more spam   │",
+            "│   spam \x1b[31meggs\x1b[0m │ & eggs      │",
+            "╞═════════════╪═════════════╡",
+            "│           2 │ foo         │",
+            "│             │ bar         │",
+            "╘═════════════╧═════════════╛",
+        ]
+    )
     result = tabulate(table, headers, tablefmt="fancy_grid")
     assert_equal(expected, result)
 
@@ -378,76 +422,85 @@ def test_fancy_grid_multiline():
 def test_fancy_grid_multiline_with_empty_cells():
     "Output: fancy_grid with multiline cells and empty cells with headers"
     table = [
-        ['hdr', 'data', 'fold'],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
+        ["hdr", "data", "fold"],
+        ["1", "", ""],
+        ["2", "very long data", "fold\nthis"],
     ]
-    expected = "\n".join([
-        "╒═══════╤════════════════╤════════╕",
-        "│   hdr │ data           │ fold   │",
-        "╞═══════╪════════════════╪════════╡",
-        "│     1 │                │        │",
-        "├───────┼────────────────┼────────┤",
-        "│     2 │ very long data │ fold   │",
-        "│       │                │ this   │",
-        "╘═══════╧════════════════╧════════╛"])
+    expected = "\n".join(
+        [
+            "╒═══════╤════════════════╤════════╕",
+            "│   hdr │ data           │ fold   │",
+            "╞═══════╪════════════════╪════════╡",
+            "│     1 │                │        │",
+            "├───────┼────────────────┼────────┤",
+            "│     2 │ very long data │ fold   │",
+            "│       │                │ this   │",
+            "╘═══════╧════════════════╧════════╛",
+        ]
+    )
     result = tabulate(table, headers="firstrow", tablefmt="fancy_grid")
     assert_equal(expected, result)
 
 
 def test_fancy_grid_multiline_with_empty_cells_headerless():
     "Output: fancy_grid with multiline cells and empty cells without headers"
-    table = [
-        ['0', '', ''],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
-    ]
-    expected = "\n".join([
-        "╒═══╤════════════════╤══════╕",
-        "│ 0 │                │      │",
-        "├───┼────────────────┼──────┤",
-        "│ 1 │                │      │",
-        "├───┼────────────────┼──────┤",
-        "│ 2 │ very long data │ fold │",
-        "│   │                │ this │",
-        "╘═══╧════════════════╧══════╛"])
+    table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+    expected = "\n".join(
+        [
+            "╒═══╤════════════════╤══════╕",
+            "│ 0 │                │      │",
+            "├───┼────────────────┼──────┤",
+            "│ 1 │                │      │",
+            "├───┼────────────────┼──────┤",
+            "│ 2 │ very long data │ fold │",
+            "│   │                │ this │",
+            "╘═══╧════════════════╧══════╛",
+        ]
+    )
     result = tabulate(table, tablefmt="fancy_grid")
     assert_equal(expected, result)
 
 
 def test_pipe():
     "Output: pipe with headers"
-    expected = '\n'.join(['| strings   |   numbers |',
-                          '|:----------|----------:|',
-                          '| spam      |   41.9999 |',
-                          '| eggs      |  451      |',])
+    expected = "\n".join(
+        [
+            "| strings   |   numbers |",
+            "|:----------|----------:|",
+            "| spam      |   41.9999 |",
+            "| eggs      |  451      |",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="pipe")
     assert_equal(expected, result)
 
 
 def test_pipe_headerless():
     "Output: pipe without headers"
-    expected = '\n'.join(['|:-----|---------:|',
-                          '| spam |  41.9999 |',
-                          '| eggs | 451      |',])
+    expected = "\n".join(
+        ["|:-----|---------:|", "| spam |  41.9999 |", "| eggs | 451      |"]
+    )
     result = tabulate(_test_table, tablefmt="pipe")
     assert_equal(expected, result)
 
 
 def test_presto():
     "Output: presto with headers"
-    expected = '\n'.join([' strings   |   numbers',
-                          '-----------+-----------',
-                          ' spam      |   41.9999',
-                          ' eggs      |  451',])
+    expected = "\n".join(
+        [
+            " strings   |   numbers",
+            "-----------+-----------",
+            " spam      |   41.9999",
+            " eggs      |  451",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="presto")
     assert_equal(expected, result)
 
 
 def test_presto_headerless():
     "Output: presto without headers"
-    expected = '\n'.join([' spam |  41.9999',
-                          ' eggs | 451',])
+    expected = "\n".join([" spam |  41.9999", " eggs | 451"])
     result = tabulate(_test_table, tablefmt="presto")
     assert_equal(expected, result)
 
@@ -455,12 +508,15 @@ def test_presto_headerless():
 def test_presto_multiline_headerless():
     "Output: presto with multiline cells without headers"
     table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
-    expected = "\n".join([
-        " foo bar |   hello",
-        "   baz   |",
-        "   bau   |",
-        "         | multiline",
-        "         |   world"])
+    expected = "\n".join(
+        [
+            " foo bar |   hello",
+            "   baz   |",
+            "   bau   |",
+            "         | multiline",
+            "         |   world",
+        ]
+    )
     result = tabulate(table, stralign="center", tablefmt="presto")
     assert_equal(expected, result)
 
@@ -469,12 +525,15 @@ def test_presto_multiline():
     "Output: presto with multiline cells with headers"
     table = [[2, "foo\nbar"]]
     headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
-    expected = "\n".join([
-        "        more | more spam",
-        "   spam \x1b[31meggs\x1b[0m | & eggs",
-        "-------------+-------------",
-        "           2 | foo",
-        "             | bar"])
+    expected = "\n".join(
+        [
+            "        more | more spam",
+            "   spam \x1b[31meggs\x1b[0m | & eggs",
+            "-------------+-------------",
+            "           2 | foo",
+            "             | bar",
+        ]
+    )
     result = tabulate(table, headers, tablefmt="presto")
     assert_equal(expected, result)
 
@@ -482,84 +541,103 @@ def test_presto_multiline():
 def test_presto_multiline_with_empty_cells():
     "Output: presto with multiline cells and empty cells with headers"
     table = [
-        ['hdr', 'data', 'fold'],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
+        ["hdr", "data", "fold"],
+        ["1", "", ""],
+        ["2", "very long data", "fold\nthis"],
     ]
-    expected = "\n".join([
-        "   hdr | data           | fold",
-        "-------+----------------+--------",
-        "     1 |                |",
-        "     2 | very long data | fold",
-        "       |                | this"])
+    expected = "\n".join(
+        [
+            "   hdr | data           | fold",
+            "-------+----------------+--------",
+            "     1 |                |",
+            "     2 | very long data | fold",
+            "       |                | this",
+        ]
+    )
     result = tabulate(table, headers="firstrow", tablefmt="presto")
     assert_equal(expected, result)
 
 
 def test_presto_multiline_with_empty_cells_headerless():
     "Output: presto with multiline cells and empty cells without headers"
-    table = [
-        ['0', '', ''],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
-    ]
-    expected = "\n".join([
-        " 0 |                |",
-        " 1 |                |",
-        " 2 | very long data | fold",
-        "   |                | this"])
+    table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+    expected = "\n".join(
+        [
+            " 0 |                |",
+            " 1 |                |",
+            " 2 | very long data | fold",
+            "   |                | this",
+        ]
+    )
     result = tabulate(table, tablefmt="presto")
     assert_equal(expected, result)
 
 
 def test_orgtbl():
     "Output: orgtbl with headers"
-    expected = '\n'.join(['| strings   |   numbers |',
-                          '|-----------+-----------|',
-                          '| spam      |   41.9999 |',
-                          '| eggs      |  451      |',])
+    expected = "\n".join(
+        [
+            "| strings   |   numbers |",
+            "|-----------+-----------|",
+            "| spam      |   41.9999 |",
+            "| eggs      |  451      |",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="orgtbl")
     assert_equal(expected, result)
 
 
 def test_orgtbl_headerless():
     "Output: orgtbl without headers"
-    expected = '\n'.join(['| spam |  41.9999 |',
-                          '| eggs | 451      |',])
+    expected = "\n".join(["| spam |  41.9999 |", "| eggs | 451      |"])
     result = tabulate(_test_table, tablefmt="orgtbl")
     assert_equal(expected, result)
 
+
 def test_psql():
     "Output: psql with headers"
-    expected = '\n'.join(['+-----------+-----------+',
-                          '| strings   |   numbers |',
-                          '|-----------+-----------|',
-                          '| spam      |   41.9999 |',
-                          '| eggs      |  451      |',
-                          '+-----------+-----------+',])
+    expected = "\n".join(
+        [
+            "+-----------+-----------+",
+            "| strings   |   numbers |",
+            "|-----------+-----------|",
+            "| spam      |   41.9999 |",
+            "| eggs      |  451      |",
+            "+-----------+-----------+",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="psql")
     assert_equal(expected, result)
 
+
 def test_psql_headerless():
     "Output: psql without headers"
-    expected = '\n'.join(['+------+----------+',
-                          '| spam |  41.9999 |',
-                          '| eggs | 451      |',
-                          '+------+----------+',])
+    expected = "\n".join(
+        [
+            "+------+----------+",
+            "| spam |  41.9999 |",
+            "| eggs | 451      |",
+            "+------+----------+",
+        ]
+    )
     result = tabulate(_test_table, tablefmt="psql")
     assert_equal(expected, result)
+
 
 def test_psql_multiline_headerless():
     "Output: psql with multiline cells without headers"
     table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
-    expected = "\n".join([
-        "+---------+-----------+",
-        "| foo bar |   hello   |",
-        "|   baz   |           |",
-        "|   bau   |           |",
-        "|         | multiline |",
-        "|         |   world   |",
-        "+---------+-----------+"])
+    expected = "\n".join(
+        [
+            "+---------+-----------+",
+            "| foo bar |   hello   |",
+            "|   baz   |           |",
+            "|   bau   |           |",
+            "|         | multiline |",
+            "|         |   world   |",
+            "+---------+-----------+",
+        ]
+    )
     result = tabulate(table, stralign="center", tablefmt="psql")
     assert_equal(expected, result)
 
@@ -568,14 +646,17 @@ def test_psql_multiline():
     "Output: psql with multiline cells with headers"
     table = [[2, "foo\nbar"]]
     headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
-    expected = "\n".join([
-        "+-------------+-------------+",
-        "|        more | more spam   |",
-        "|   spam \x1b[31meggs\x1b[0m | & eggs      |",
-        "|-------------+-------------|",
-        "|           2 | foo         |",
-        "|             | bar         |",
-        "+-------------+-------------+"])
+    expected = "\n".join(
+        [
+            "+-------------+-------------+",
+            "|        more | more spam   |",
+            "|   spam \x1b[31meggs\x1b[0m | & eggs      |",
+            "|-------------+-------------|",
+            "|           2 | foo         |",
+            "|             | bar         |",
+            "+-------------+-------------+",
+        ]
+    )
     result = tabulate(table, headers, tablefmt="psql")
     assert_equal(expected, result)
 
@@ -583,102 +664,122 @@ def test_psql_multiline():
 def test_psql_multiline_with_empty_cells():
     "Output: psql with multiline cells and empty cells with headers"
     table = [
-        ['hdr', 'data', 'fold'],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
+        ["hdr", "data", "fold"],
+        ["1", "", ""],
+        ["2", "very long data", "fold\nthis"],
     ]
-    expected = "\n".join([
-        "+-------+----------------+--------+",
-        "|   hdr | data           | fold   |",
-        "|-------+----------------+--------|",
-        "|     1 |                |        |",
-        "|     2 | very long data | fold   |",
-        "|       |                | this   |",
-        "+-------+----------------+--------+"])
+    expected = "\n".join(
+        [
+            "+-------+----------------+--------+",
+            "|   hdr | data           | fold   |",
+            "|-------+----------------+--------|",
+            "|     1 |                |        |",
+            "|     2 | very long data | fold   |",
+            "|       |                | this   |",
+            "+-------+----------------+--------+",
+        ]
+    )
     result = tabulate(table, headers="firstrow", tablefmt="psql")
     assert_equal(expected, result)
 
 
 def test_psql_multiline_with_empty_cells_headerless():
     "Output: psql with multiline cells and empty cells without headers"
-    table = [
-        ['0', '', ''],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
-    ]
-    expected = "\n".join([
-        "+---+----------------+------+",
-        "| 0 |                |      |",
-        "| 1 |                |      |",
-        "| 2 | very long data | fold |",
-        "|   |                | this |",
-        "+---+----------------+------+"])
+    table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+    expected = "\n".join(
+        [
+            "+---+----------------+------+",
+            "| 0 |                |      |",
+            "| 1 |                |      |",
+            "| 2 | very long data | fold |",
+            "|   |                | this |",
+            "+---+----------------+------+",
+        ]
+    )
     result = tabulate(table, tablefmt="psql")
     assert_equal(expected, result)
 
 
 def test_jira():
     "Output: jira with headers"
-    expected = '\n'.join(['|| strings   ||   numbers ||',
-                          '| spam      |   41.9999 |',
-                          '| eggs      |  451      |',])
+    expected = "\n".join(
+        [
+            "|| strings   ||   numbers ||",
+            "| spam      |   41.9999 |",
+            "| eggs      |  451      |",
+        ]
+    )
 
     result = tabulate(_test_table, _test_table_headers, tablefmt="jira")
     assert_equal(expected, result)
 
+
 def test_jira_headerless():
     "Output: jira without headers"
-    expected = '\n'.join(['| spam |  41.9999 |',
-                          '| eggs | 451      |',])
+    expected = "\n".join(["| spam |  41.9999 |", "| eggs | 451      |"])
 
     result = tabulate(_test_table, tablefmt="jira")
     assert_equal(expected, result)
 
+
 def test_rst():
     "Output: rst with headers"
-    expected = '\n'.join(['=========  =========',
-                          'strings      numbers',
-                          '=========  =========',
-                          'spam         41.9999',
-                          'eggs        451',
-                          '=========  =========',])
+    expected = "\n".join(
+        [
+            "=========  =========",
+            "strings      numbers",
+            "=========  =========",
+            "spam         41.9999",
+            "eggs        451",
+            "=========  =========",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="rst")
     assert_equal(expected, result)
 
+
 def test_rst_with_empty_values_in_first_column():
     "Output: rst with dots in first column"
-    test_headers = ['', 'what']
-    test_data = [('', 'spam'), ('', 'eggs')]
-    expected = '\n'.join(['====  ======',
-                          '..    what',
-                          '====  ======',
-                          '..    spam',
-                          '..    eggs',
-                          '====  ======'])
+    test_headers = ["", "what"]
+    test_data = [("", "spam"), ("", "eggs")]
+    expected = "\n".join(
+        [
+            "====  ======",
+            "..    what",
+            "====  ======",
+            "..    spam",
+            "..    eggs",
+            "====  ======",
+        ]
+    )
     result = tabulate(test_data, test_headers, tablefmt="rst")
     assert_equal(expected, result)
 
+
 def test_rst_headerless():
     "Output: rst without headers"
-    expected = '\n'.join(['====  ========',
-                          'spam   41.9999',
-                          'eggs  451',
-                          '====  ========',])
+    expected = "\n".join(
+        ["====  ========", "spam   41.9999", "eggs  451", "====  ========"]
+    )
     result = tabulate(_test_table, tablefmt="rst")
     assert_equal(expected, result)
+
 
 def test_rst_multiline():
     "Output: rst with multiline cells with headers"
     table = [[2, "foo\nbar"]]
     headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
-    expected = "\n".join([
-        "===========  ===========",
-        "       more  more spam",
-        "  spam \x1b[31meggs\x1b[0m  & eggs",
-        "===========  ===========",
-        "          2  foo",
-        "             bar",
-        "===========  ==========="])
+    expected = "\n".join(
+        [
+            "===========  ===========",
+            "       more  more spam",
+            "  spam \x1b[31meggs\x1b[0m  & eggs",
+            "===========  ===========",
+            "          2  foo",
+            "             bar",
+            "===========  ===========",
+        ]
+    )
     result = tabulate(table, headers, tablefmt="rst")
     assert_equal(expected, result)
 
@@ -686,117 +787,147 @@ def test_rst_multiline():
 def test_rst_multiline_with_empty_cells():
     "Output: rst with multiline cells and empty cells with headers"
     table = [
-        ['hdr', 'data', 'fold'],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
+        ["hdr", "data", "fold"],
+        ["1", "", ""],
+        ["2", "very long data", "fold\nthis"],
     ]
-    expected = "\n".join([
-        "=====  ==============  ======",
-        "  hdr  data            fold",
-        "=====  ==============  ======",
-        "    1",
-        "    2  very long data  fold",
-        "                       this",
-        "=====  ==============  ======"])
+    expected = "\n".join(
+        [
+            "=====  ==============  ======",
+            "  hdr  data            fold",
+            "=====  ==============  ======",
+            "    1",
+            "    2  very long data  fold",
+            "                       this",
+            "=====  ==============  ======",
+        ]
+    )
     result = tabulate(table, headers="firstrow", tablefmt="rst")
     assert_equal(expected, result)
 
 
 def test_rst_multiline_with_empty_cells_headerless():
     "Output: rst with multiline cells and empty cells without headers"
-    table = [
-        ['0', '', ''],
-        ['1', '', ''],
-        ['2', 'very long data', 'fold\nthis']
-    ]
-    expected = "\n".join([
-        "=  ==============  ====",
-        "0",
-        "1",
-        "2  very long data  fold",
-        "                   this",
-        "=  ==============  ===="])
+    table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+    expected = "\n".join(
+        [
+            "=  ==============  ====",
+            "0",
+            "1",
+            "2  very long data  fold",
+            "                   this",
+            "=  ==============  ====",
+        ]
+    )
     result = tabulate(table, tablefmt="rst")
     assert_equal(expected, result)
 
 
 def test_mediawiki():
     "Output: mediawiki with headers"
-    expected = '\n'.join(['{| class="wikitable" style="text-align: left;"',
-                          '|+ <!-- caption -->',
-                          '|-',
-                          '! strings   !! align="right"|   numbers',
-                          '|-',
-                          '| spam      || align="right"|   41.9999',
-                          '|-',
-                          '| eggs      || align="right"|  451',
-                          '|}',])
+    expected = "\n".join(
+        [
+            '{| class="wikitable" style="text-align: left;"',
+            "|+ <!-- caption -->",
+            "|-",
+            '! strings   !! align="right"|   numbers',
+            "|-",
+            '| spam      || align="right"|   41.9999',
+            "|-",
+            '| eggs      || align="right"|  451',
+            "|}",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="mediawiki")
     assert_equal(expected, result)
 
 
 def test_mediawiki_headerless():
     "Output: mediawiki without headers"
-    expected = '\n'.join(['{| class="wikitable" style="text-align: left;"',
-                          '|+ <!-- caption -->',
-                          '|-',
-                          '| spam || align="right"|  41.9999',
-                          '|-',
-                          '| eggs || align="right"| 451',
-                          '|}',])
+    expected = "\n".join(
+        [
+            '{| class="wikitable" style="text-align: left;"',
+            "|+ <!-- caption -->",
+            "|-",
+            '| spam || align="right"|  41.9999',
+            "|-",
+            '| eggs || align="right"| 451',
+            "|}",
+        ]
+    )
     result = tabulate(_test_table, tablefmt="mediawiki")
     assert_equal(expected, result)
 
+
 def test_moinmoin():
     "Output: moinmoin with headers"
-    expected = "\n".join(['|| \'\'\' strings   \'\'\' ||<style="text-align: right;"> \'\'\'   numbers \'\'\' ||',
-                          '||  spam       ||<style="text-align: right;">    41.9999  ||',
-                          '||  eggs       ||<style="text-align: right;">   451       ||',])
+    expected = "\n".join(
+        [
+            "|| ''' strings   ''' ||<style=\"text-align: right;\"> '''   numbers ''' ||",
+            '||  spam       ||<style="text-align: right;">    41.9999  ||',
+            '||  eggs       ||<style="text-align: right;">   451       ||',
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="moinmoin")
     assert_equal(expected, result)
 
+
 def test_youtrack():
     "Output: youtrack with headers"
-    expected = "\n".join(['||  strings    ||    numbers  ||',
-                          '|  spam       |    41.9999  |',
-                          '|  eggs       |   451       |',])
+    expected = "\n".join(
+        [
+            "||  strings    ||    numbers  ||",
+            "|  spam       |    41.9999  |",
+            "|  eggs       |   451       |",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="youtrack")
     assert_equal(expected, result)
 
 
 def test_moinmoin_headerless():
     "Output: moinmoin without headers"
-    expected = "\n".join(['||  spam  ||<style="text-align: right;">   41.9999  ||',
-                          '||  eggs  ||<style="text-align: right;">  451       ||',])
-    result = tabulate (_test_table, tablefmt="moinmoin")
+    expected = "\n".join(
+        [
+            '||  spam  ||<style="text-align: right;">   41.9999  ||',
+            '||  eggs  ||<style="text-align: right;">  451       ||',
+        ]
+    )
+    result = tabulate(_test_table, tablefmt="moinmoin")
     assert_equal(expected, result)
 
 
 def test_html():
     "Output: html with headers"
-    expected = '\n'.join([
-        '<table>',
-        '<thead>',
-        '<tr><th>strings  </th><th style="text-align: right;">  numbers</th></tr>',
-        '</thead>',
-        '<tbody>',
-        '<tr><td>spam     </td><td style="text-align: right;">  41.9999</td></tr>',
-        '<tr><td>eggs     </td><td style="text-align: right;"> 451     </td></tr>',
-        '</tbody>',
-        '</table>',])
+    expected = "\n".join(
+        [
+            "<table>",
+            "<thead>",
+            '<tr><th>strings  </th><th style="text-align: right;">  numbers</th></tr>',
+            "</thead>",
+            "<tbody>",
+            '<tr><td>spam     </td><td style="text-align: right;">  41.9999</td></tr>',
+            '<tr><td>eggs     </td><td style="text-align: right;"> 451     </td></tr>',
+            "</tbody>",
+            "</table>",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, tablefmt="html")
     assert_equal(expected, result)
 
 
 def test_html_headerless():
     "Output: html without headers"
-    expected = '\n'.join([
-        '<table>',
-        '<tbody>',
-        '<tr><td>spam</td><td style="text-align: right;"> 41.9999</td></tr>',
-        '<tr><td>eggs</td><td style="text-align: right;">451     </td></tr>',
-        '</tbody>',
-        '</table>',])
+    expected = "\n".join(
+        [
+            "<table>",
+            "<tbody>",
+            '<tr><td>spam</td><td style="text-align: right;"> 41.9999</td></tr>',
+            '<tr><td>eggs</td><td style="text-align: right;">451     </td></tr>',
+            "</tbody>",
+            "</table>",
+        ]
+    )
     result = tabulate(_test_table, tablefmt="html")
     assert_equal(expected, result)
 
@@ -805,70 +936,93 @@ def test_latex():
     "Output: latex with headers and replaced characters"
     raw_test_table_headers = list(_test_table_headers)
     raw_test_table_headers[-1] += " ($N_0$)"
-    result   = tabulate(_test_table, raw_test_table_headers, tablefmt="latex")
-    expected = "\n".join([r"\begin{tabular}{lr}",
-                          r"\hline",
-                          r" strings   &   numbers (\$N\_0\$) \\",
-                          r"\hline",
-                          r" spam      &           41.9999 \\",
-                          r" eggs      &          451      \\",
-                          r"\hline",
-                          r"\end{tabular}"])
+    result = tabulate(_test_table, raw_test_table_headers, tablefmt="latex")
+    expected = "\n".join(
+        [
+            r"\begin{tabular}{lr}",
+            r"\hline",
+            r" strings   &   numbers (\$N\_0\$) \\",
+            r"\hline",
+            r" spam      &           41.9999 \\",
+            r" eggs      &          451      \\",
+            r"\hline",
+            r"\end{tabular}",
+        ]
+    )
     assert_equal(expected, result)
+
 
 def test_latex_raw():
     "Output: raw latex with headers"
     raw_test_table_headers = list(_test_table_headers)
     raw_test_table_headers[-1] += " ($N_0$)"
-    raw_test_table = list(map(list,_test_table))
+    raw_test_table = list(map(list, _test_table))
     raw_test_table[0][0] += "$_1$"
     raw_test_table[1][0] = "\\emph{" + raw_test_table[1][0] + "}"
     print(raw_test_table)
-    result   = tabulate(raw_test_table, raw_test_table_headers, tablefmt="latex_raw")
-    expected = "\n".join([r"\begin{tabular}{lr}",
-                          r"\hline",
-                          r" strings     &   numbers ($N_0$) \\",
-                          r"\hline",
-                          r" spam$_1$    &           41.9999 \\",
-                          r" \emph{eggs} &          451      \\",
-                          r"\hline",
-                          r"\end{tabular}"])
+    result = tabulate(raw_test_table, raw_test_table_headers, tablefmt="latex_raw")
+    expected = "\n".join(
+        [
+            r"\begin{tabular}{lr}",
+            r"\hline",
+            r" strings     &   numbers ($N_0$) \\",
+            r"\hline",
+            r" spam$_1$    &           41.9999 \\",
+            r" \emph{eggs} &          451      \\",
+            r"\hline",
+            r"\end{tabular}",
+        ]
+    )
     assert_equal(expected, result)
+
 
 def test_latex_headerless():
     "Output: latex without headers"
-    result   = tabulate(_test_table, tablefmt="latex")
-    expected = "\n".join([r"\begin{tabular}{lr}",
-                          r"\hline",
-                          r" spam &  41.9999 \\",
-                          r" eggs & 451      \\",
-                          r"\hline",
-                          r"\end{tabular}"])
+    result = tabulate(_test_table, tablefmt="latex")
+    expected = "\n".join(
+        [
+            r"\begin{tabular}{lr}",
+            r"\hline",
+            r" spam &  41.9999 \\",
+            r" eggs & 451      \\",
+            r"\hline",
+            r"\end{tabular}",
+        ]
+    )
     assert_equal(expected, result)
+
 
 def test_latex_booktabs():
     "Output: latex with headers, using the booktabs format"
-    result   = tabulate(_test_table, _test_table_headers, tablefmt="latex_booktabs")
-    expected = "\n".join([r"\begin{tabular}{lr}",
-                          r"\toprule",
-                          r" strings   &   numbers \\",
-                          r"\midrule",
-                          r" spam      &   41.9999 \\",
-                          r" eggs      &  451      \\",
-                          r"\bottomrule",
-                          r"\end{tabular}"])
+    result = tabulate(_test_table, _test_table_headers, tablefmt="latex_booktabs")
+    expected = "\n".join(
+        [
+            r"\begin{tabular}{lr}",
+            r"\toprule",
+            r" strings   &   numbers \\",
+            r"\midrule",
+            r" spam      &   41.9999 \\",
+            r" eggs      &  451      \\",
+            r"\bottomrule",
+            r"\end{tabular}",
+        ]
+    )
     assert_equal(expected, result)
 
 
 def test_latex_booktabs_headerless():
     "Output: latex without headers, using the booktabs format"
-    result   = tabulate(_test_table, tablefmt="latex_booktabs")
-    expected = "\n".join([r"\begin{tabular}{lr}",
-                          r"\toprule",
-                          r" spam &  41.9999 \\",
-                          r" eggs & 451      \\",
-                          r"\bottomrule",
-                          r"\end{tabular}"])
+    result = tabulate(_test_table, tablefmt="latex_booktabs")
+    expected = "\n".join(
+        [
+            r"\begin{tabular}{lr}",
+            r"\toprule",
+            r" spam &  41.9999 \\",
+            r" eggs & 451      \\",
+            r"\bottomrule",
+            r"\end{tabular}",
+        ]
+    )
     assert_equal(expected, result)
 
 
@@ -884,7 +1038,7 @@ def test_textile():
 
 def test_textile_with_header():
     "Output: textile with header"
-    result = tabulate(_test_table, ['strings', 'numbers'], tablefmt="textile")
+    result = tabulate(_test_table, ["strings", "numbers"], tablefmt="textile")
     expected = """\
 |_.  strings   |_.   numbers |
 |<. spam       |>.   41.9999 |
@@ -895,7 +1049,7 @@ def test_textile_with_header():
 
 def test_textile_with_center_align():
     "Output: textile with center align"
-    result = tabulate(_test_table, tablefmt="textile", stralign='center')
+    result = tabulate(_test_table, tablefmt="textile", stralign="center")
     expected = """\
 |=. spam  |>.  41.9999 |
 |=. eggs  |>. 451      |"""
@@ -905,16 +1059,14 @@ def test_textile_with_center_align():
 
 def test_no_data():
     "Output: table with no data"
-    expected = "\n".join(['strings    numbers',
-                          '---------  ---------'])
+    expected = "\n".join(["strings    numbers", "---------  ---------"])
     result = tabulate(None, _test_table_headers, tablefmt="simple")
     assert_equal(expected, result)
 
 
 def test_empty_data():
     "Output: table with empty data"
-    expected = "\n".join(['strings    numbers',
-                          '---------  ---------'])
+    expected = "\n".join(["strings    numbers", "---------  ---------"])
     result = tabulate([], _test_table_headers, tablefmt="simple")
     assert_equal(expected, result)
 
@@ -935,79 +1087,92 @@ def test_empty_data_without_headers():
 
 def test_floatfmt():
     "Output: floating point format"
-    result = tabulate([['1.23456789'],[1.0]], floatfmt=".3f", tablefmt="plain")
-    expected = '1.235\n1.000'
+    result = tabulate([["1.23456789"], [1.0]], floatfmt=".3f", tablefmt="plain")
+    expected = "1.235\n1.000"
     assert_equal(expected, result)
 
 
 def test_floatfmt_multi():
     "Output: floating point format different for each column"
-    result = tabulate([[0.12345, 0.12345, 0.12345]], floatfmt=(".1f", ".3f"), tablefmt="plain")
-    expected = '0.1  0.123  0.12345'
+    result = tabulate(
+        [[0.12345, 0.12345, 0.12345]], floatfmt=(".1f", ".3f"), tablefmt="plain"
+    )
+    expected = "0.1  0.123  0.12345"
     assert_equal(expected, result)
+
 
 def test_colalign_multi():
     "Output: string columns with custom colalign"
-    result = tabulate([["one", "two"], ["three", "four"]], colalign=("right",), tablefmt="plain")
-    expected = '  one  two\nthree  four'
+    result = tabulate(
+        [["one", "two"], ["three", "four"]], colalign=("right",), tablefmt="plain"
+    )
+    expected = "  one  two\nthree  four"
     assert_equal(expected, result)
+
 
 def test_float_conversions():
     "Output: float format parsed"
-    test_headers = ["str", "bad_float", "just_float", 'with_inf', 'with_nan', 'neg_inf']
+    test_headers = ["str", "bad_float", "just_float", "with_inf", "with_nan", "neg_inf"]
     test_table = [
-        ["spam", 41.9999, "123.345", '12.2', 'nan', '0.123123'],
-        ["eggs", "451.0", 66.2222, 'inf', 123.1234, '-inf'],
-        ["asd", "437e6548", 1.234e2, float('inf'), float('nan'), 0.22e23]
+        ["spam", 41.9999, "123.345", "12.2", "nan", "0.123123"],
+        ["eggs", "451.0", 66.2222, "inf", 123.1234, "-inf"],
+        ["asd", "437e6548", 1.234e2, float("inf"), float("nan"), 0.22e23],
     ]
     result = tabulate(test_table, test_headers, tablefmt="grid")
-    expected = "\n".join([
-        '+-------+-------------+--------------+------------+------------+-------------+',
-        '| str   | bad_float   |   just_float |   with_inf |   with_nan |     neg_inf |',
-        '+=======+=============+==============+============+============+=============+',
-        '| spam  | 41.9999     |     123.345  |       12.2 |    nan     |    0.123123 |',
-        '+-------+-------------+--------------+------------+------------+-------------+',
-        '| eggs  | 451.0       |      66.2222 |      inf   |    123.123 | -inf        |',
-        '+-------+-------------+--------------+------------+------------+-------------+',
-        '| asd   | 437e6548    |     123.4    |      inf   |    nan     |    2.2e+22  |',
-        '+-------+-------------+--------------+------------+------------+-------------+'
-    ])
+    expected = "\n".join(
+        [
+            "+-------+-------------+--------------+------------+------------+-------------+",
+            "| str   | bad_float   |   just_float |   with_inf |   with_nan |     neg_inf |",
+            "+=======+=============+==============+============+============+=============+",
+            "| spam  | 41.9999     |     123.345  |       12.2 |    nan     |    0.123123 |",
+            "+-------+-------------+--------------+------------+------------+-------------+",
+            "| eggs  | 451.0       |      66.2222 |      inf   |    123.123 | -inf        |",
+            "+-------+-------------+--------------+------------+------------+-------------+",
+            "| asd   | 437e6548    |     123.4    |      inf   |    nan     |    2.2e+22  |",
+            "+-------+-------------+--------------+------------+------------+-------------+",
+        ]
+    )
     assert_equal(expected, result)
+
 
 def test_missingval():
     "Output: substitution of missing values"
-    result = tabulate([['Alice', 10],['Bob', None]], missingval="n/a", tablefmt="plain")
-    expected = 'Alice   10\nBob    n/a'
+    result = tabulate(
+        [["Alice", 10], ["Bob", None]], missingval="n/a", tablefmt="plain"
+    )
+    expected = "Alice   10\nBob    n/a"
     assert_equal(expected, result)
 
 
 def test_missingval_multi():
     "Output: substitution of missing values with different values per column"
-    result = tabulate([["Alice", "Bob", "Charlie"], [None, None, None]],
-                      missingval=("n/a", "?"), tablefmt="plain")
-    expected = 'Alice  Bob  Charlie\nn/a    ?'
+    result = tabulate(
+        [["Alice", "Bob", "Charlie"], [None, None, None]],
+        missingval=("n/a", "?"),
+        tablefmt="plain",
+    )
+    expected = "Alice  Bob  Charlie\nn/a    ?"
     assert_equal(expected, result)
 
 
 def test_column_alignment():
     "Output: custom alignment for text and numbers"
-    expected = '\n'.join(['-----  ---',
-                          'Alice   1',
-                          '  Bob  333',
-                          '-----  ---',])
-    result = tabulate([['Alice', 1],['Bob', 333]], stralign="right", numalign="center")
+    expected = "\n".join(["-----  ---", "Alice   1", "  Bob  333", "-----  ---"])
+    result = tabulate([["Alice", 1], ["Bob", 333]], stralign="right", numalign="center")
     assert_equal(expected, result)
 
 
 def test_unaligned_separated():
     "Output: non-aligned data columns"
-    expected = '\n'.join(['name|score',
-                          'Alice|1',
-                          'Bob|333'])
+    expected = "\n".join(["name|score", "Alice|1", "Bob|333"])
     fmt = simple_separated_format("|")
-    result = tabulate([['Alice', 1],['Bob', 333]],
-                      ["name", "score"],
-                      tablefmt=fmt, stralign=None, numalign=None)
+    result = tabulate(
+        [["Alice", 1], ["Bob", 333]],
+        ["name", "score"],
+        tablefmt=fmt,
+        stralign=None,
+        numalign=None,
+    )
     assert_equal(expected, result)
 
 
@@ -1015,194 +1180,210 @@ def test_pandas_with_index():
     "Output: a pandas Dataframe with an index"
     try:
         import pandas
-        df = pandas.DataFrame([["one",1],["two",None]],
-                              columns=["string","number"],
-                              index=["a","b"])
+
+        df = pandas.DataFrame(
+            [["one", 1], ["two", None]], columns=["string", "number"], index=["a", "b"]
+        )
         expected = "\n".join(
-            ['    string      number',
-             '--  --------  --------',
-             'a   one              1',
-             'b   two            nan'])
+            [
+                "    string      number",
+                "--  --------  --------",
+                "a   one              1",
+                "b   two            nan",
+            ]
+        )
         result = tabulate(df, headers="keys")
         assert_equal(expected, result)
     except ImportError:
         print("test_pandas_with_index is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_pandas_without_index():
     "Output: a pandas Dataframe without an index"
     try:
         import pandas
-        df = pandas.DataFrame([["one",1],["two",None]],
-                              columns=["string","number"],
-                              index=["a","b"])
+
+        df = pandas.DataFrame(
+            [["one", 1], ["two", None]], columns=["string", "number"], index=["a", "b"]
+        )
         expected = "\n".join(
-            ['string      number',
-             '--------  --------',
-             'one              1',
-             'two            nan'])
+            [
+                "string      number",
+                "--------  --------",
+                "one              1",
+                "two            nan",
+            ]
+        )
         result = tabulate(df, headers="keys", showindex=False)
         assert_equal(expected, result)
     except ImportError:
         print("test_pandas_without_index is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_pandas_rst_with_index():
     "Output: a pandas Dataframe with an index in ReStructuredText format"
     try:
         import pandas
-        df = pandas.DataFrame([["one", 1], ["two", None]],
-                              columns=["string", "number"],
-                              index=["a", "b"])
+
+        df = pandas.DataFrame(
+            [["one", 1], ["two", None]], columns=["string", "number"], index=["a", "b"]
+        )
         expected = "\n".join(
-            ['====  ========  ========',
-             '..    string      number',
-             '====  ========  ========',
-             'a     one              1',
-             'b     two            nan',
-             '====  ========  ========'])
+            [
+                "====  ========  ========",
+                "..    string      number",
+                "====  ========  ========",
+                "a     one              1",
+                "b     two            nan",
+                "====  ========  ========",
+            ]
+        )
         result = tabulate(df, tablefmt="rst", headers="keys")
         assert_equal(expected, result)
     except ImportError:
         print("test_pandas_rst_with_index is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_pandas_rst_with_named_index():
     "Output: a pandas Dataframe with a named index in ReStructuredText format"
     try:
         import pandas
-        index = pandas.Index(["a", "b"], name='index')
-        df = pandas.DataFrame([["one", 1], ["two", None]],
-                              columns=["string", "number"],
-                              index=index)
+
+        index = pandas.Index(["a", "b"], name="index")
+        df = pandas.DataFrame(
+            [["one", 1], ["two", None]], columns=["string", "number"], index=index
+        )
         expected = "\n".join(
-            ['=======  ========  ========',
-             'index    string      number',
-             '=======  ========  ========',
-             'a        one              1',
-             'b        two            nan',
-             '=======  ========  ========'])
+            [
+                "=======  ========  ========",
+                "index    string      number",
+                "=======  ========  ========",
+                "a        one              1",
+                "b        two            nan",
+                "=======  ========  ========",
+            ]
+        )
         result = tabulate(df, tablefmt="rst", headers="keys")
         assert_equal(expected, result)
     except ImportError:
         print("test_pandas_rst_with_index is skipped")
-        raise SkipTest()   # this test is optional
+        raise SkipTest()  # this test is optional
 
 
 def test_dict_like_with_index():
     "Output: a table with a running index"
-    dd = {"b": range(101,104)}
-    expected = "\n".join([
-        '      b',
-        '--  ---',
-        ' 0  101',
-        ' 1  102',
-        ' 2  103'])
+    dd = {"b": range(101, 104)}
+    expected = "\n".join(["      b", "--  ---", " 0  101", " 1  102", " 2  103"])
     result = tabulate(dd, "keys", showindex=True)
     assert_equal(result, expected)
 
 
 def test_list_of_lists_with_index():
     "Output: a table with a running index"
-    dd = zip(*[range(3), range(101,104)])
+    dd = zip(*[range(3), range(101, 104)])
     # keys' order (hence columns' order) is not deterministic in Python 3
     # => we have to consider both possible results as valid
-    expected = "\n".join([
-        '      a    b',
-        '--  ---  ---',
-        ' 0    0  101',
-        ' 1    1  102',
-        ' 2    2  103'])
-    result = tabulate(dd, headers=["a","b"], showindex=True)
+    expected = "\n".join(
+        ["      a    b", "--  ---  ---", " 0    0  101", " 1    1  102", " 2    2  103"]
+    )
+    result = tabulate(dd, headers=["a", "b"], showindex=True)
     assert_equal(result, expected)
+
 
 def test_list_of_lists_with_supplied_index():
     "Output: a table with a supplied index"
-    dd = zip(*[list(range(3)), list(range(101,104))])
-    expected = "\n".join([
-        '      a    b',
-        '--  ---  ---',
-        ' 1    0  101',
-        ' 2    1  102',
-        ' 3    2  103'])
-    result    = tabulate(dd, headers=["a","b"], showindex=[1,2,3])
+    dd = zip(*[list(range(3)), list(range(101, 104))])
+    expected = "\n".join(
+        ["      a    b", "--  ---  ---", " 1    0  101", " 2    1  102", " 3    2  103"]
+    )
+    result = tabulate(dd, headers=["a", "b"], showindex=[1, 2, 3])
     assert_equal(result, expected)
     # TODO: make it a separate test case
     # the index must be as long as the number of rows
-    assert_raises(ValueError, lambda: tabulate(dd, headers=["a","b"], showindex=[1,2]))
+    assert_raises(
+        ValueError, lambda: tabulate(dd, headers=["a", "b"], showindex=[1, 2])
+    )
 
 
 def test_list_of_lists_with_index_firstrow():
     "Output: a table with a running index and header='firstrow'"
-    dd = zip(*[["a"]+list(range(3)), ["b"]+list(range(101,104))])
-    expected = "\n".join([
-        '      a    b',
-        '--  ---  ---',
-        ' 0    0  101',
-        ' 1    1  102',
-        ' 2    2  103'])
+    dd = zip(*[["a"] + list(range(3)), ["b"] + list(range(101, 104))])
+    expected = "\n".join(
+        ["      a    b", "--  ---  ---", " 0    0  101", " 1    1  102", " 2    2  103"]
+    )
     result = tabulate(dd, headers="firstrow", showindex=True)
     assert_equal(result, expected)
     # TODO: make it a separate test case
     # the index must be as long as the number of rows
-    assert_raises(ValueError, lambda: tabulate(dd, headers="firstrow", showindex=[1,2]))
+    assert_raises(
+        ValueError, lambda: tabulate(dd, headers="firstrow", showindex=[1, 2])
+    )
 
 
 def test_disable_numparse_default():
     "Output: Default table output with number parsing and alignment"
-    expected = "\n".join(['strings      numbers',
-                          '---------  ---------',
-                          'spam         41.9999',
-                          'eggs        451',])
+    expected = "\n".join(
+        [
+            "strings      numbers",
+            "---------  ---------",
+            "spam         41.9999",
+            "eggs        451",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers)
     assert_equal(expected, result)
     result = tabulate(_test_table, _test_table_headers, disable_numparse=False)
     assert_equal(expected, result)
 
+
 def test_disable_numparse_true():
     "Output: Default table output, but without number parsing and alignment"
-    expected = "\n".join(['strings    numbers',
-                          '---------  ---------',
-                          'spam       41.9999',
-                          'eggs       451.0',])
+    expected = "\n".join(
+        [
+            "strings    numbers",
+            "---------  ---------",
+            "spam       41.9999",
+            "eggs       451.0",
+        ]
+    )
     result = tabulate(_test_table, _test_table_headers, disable_numparse=True)
     assert_equal(expected, result)
 
+
 def test_disable_numparse_list():
     "Output: Default table output, but with number parsing selectively disabled"
-    table_headers = ['h1', 'h2', 'h3']
-    test_table = [['foo', 'bar', '42992e1']]
-    expected = "\n".join(['h1    h2    h3',
-                          '----  ----  -------',
-                          'foo   bar   42992e1',])
+    table_headers = ["h1", "h2", "h3"]
+    test_table = [["foo", "bar", "42992e1"]]
+    expected = "\n".join(
+        ["h1    h2    h3", "----  ----  -------", "foo   bar   42992e1"]
+    )
     result = tabulate(test_table, table_headers, disable_numparse=[2])
     assert_equal(expected, result)
 
-    expected = "\n".join(['h1    h2        h3',
-                          '----  ----  ------',
-                          'foo   bar   429920',])
+    expected = "\n".join(
+        ["h1    h2        h3", "----  ----  ------", "foo   bar   429920"]
+    )
     result = tabulate(test_table, table_headers, disable_numparse=[0, 1])
     assert_equal(expected, result)
+
 
 def test_preserve_whitespace():
     "Output: Default table output, but with preserved leading whitespace."
     tabulate_module.PRESERVE_WHITESPACE = True
-    table_headers = ['h1', 'h2', 'h3']
-    test_table = [['  foo', ' bar   ', 'foo']]
-    expected = "\n".join(['h1     h2       h3',
-                          '-----  -------  ----',
-                          '  foo   bar     foo'])
+    table_headers = ["h1", "h2", "h3"]
+    test_table = [["  foo", " bar   ", "foo"]]
+    expected = "\n".join(
+        ["h1     h2       h3", "-----  -------  ----", "  foo   bar     foo"]
+    )
     result = tabulate(test_table, table_headers)
     assert_equal(expected, result)
 
     tabulate_module.PRESERVE_WHITESPACE = False
-    table_headers = ['h1', 'h2', 'h3']
-    test_table = [['  foo', ' bar   ', 'foo']]
-    expected = "\n".join(['h1    h2    h3',
-                          '----  ----  ----',
-                          'foo   bar   foo'])
+    table_headers = ["h1", "h2", "h3"]
+    test_table = [["  foo", " bar   ", "foo"]]
+    expected = "\n".join(["h1    h2    h3", "----  ----  ----", "foo   bar   foo"])
     result = tabulate(test_table, table_headers)
     assert_equal(expected, result)

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -10,28 +10,39 @@ from common import assert_equal, assert_in, SkipTest
 
 def test_ansi_color_in_table_cells():
     "Regression: ANSI color in table cells (issue #5)."
-    colortable = [('test', '\x1b[31mtest\x1b[0m', '\x1b[32mtest\x1b[0m')]
-    colorlessheaders = ('test', 'test', 'test')
-    formatted = tabulate(colortable, colorlessheaders, 'pipe')
-    expected = "\n".join(['| test   | test   | test   |',
-                          '|:-------|:-------|:-------|',
-                          '| test   | \x1b[31mtest\x1b[0m   | \x1b[32mtest\x1b[0m   |'])
+    colortable = [("test", "\x1b[31mtest\x1b[0m", "\x1b[32mtest\x1b[0m")]
+    colorlessheaders = ("test", "test", "test")
+    formatted = tabulate(colortable, colorlessheaders, "pipe")
+    expected = "\n".join(
+        [
+            "| test   | test   | test   |",
+            "|:-------|:-------|:-------|",
+            "| test   | \x1b[31mtest\x1b[0m   | \x1b[32mtest\x1b[0m   |",
+        ]
+    )
     print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
     assert_equal(expected, formatted)
 
 
 def test_alignment_of_colored_cells():
     "Regression: Align ANSI-colored values as if they were colorless."
-    colortable = [('test', 42, '\x1b[31m42\x1b[0m'), ('test', 101, '\x1b[32m101\x1b[0m')]
-    colorheaders = ('test', '\x1b[34mtest\x1b[0m', 'test')
-    formatted = tabulate(colortable, colorheaders, 'grid')
-    expected = '\n'.join(['+--------+--------+--------+',
-                          '| test   |   \x1b[34mtest\x1b[0m |   test |',
-                          '+========+========+========+',
-                          '| test   |     42 |     \x1b[31m42\x1b[0m |',
-                          '+--------+--------+--------+',
-                          '| test   |    101 |    \x1b[32m101\x1b[0m |',
-                          '+--------+--------+--------+'])
+    colortable = [
+        ("test", 42, "\x1b[31m42\x1b[0m"),
+        ("test", 101, "\x1b[32m101\x1b[0m"),
+    ]
+    colorheaders = ("test", "\x1b[34mtest\x1b[0m", "test")
+    formatted = tabulate(colortable, colorheaders, "grid")
+    expected = "\n".join(
+        [
+            "+--------+--------+--------+",
+            "| test   |   \x1b[34mtest\x1b[0m |   test |",
+            "+========+========+========+",
+            "| test   |     42 |     \x1b[31m42\x1b[0m |",
+            "+--------+--------+--------+",
+            "| test   |    101 |    \x1b[32m101\x1b[0m |",
+            "+--------+--------+--------+",
+        ]
+    )
     print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
     assert_equal(expected, formatted)
 
@@ -43,6 +54,7 @@ def test_iter_of_iters_with_headers():
         def mk_iter():
             for i in range(3):
                 yield i
+
         for r in range(3):
             yield mk_iter()
 
@@ -51,11 +63,15 @@ def test_iter_of_iters_with_headers():
             yield h
 
     formatted = tabulate(mk_iter_of_iters(), headers=mk_headers())
-    expected = '\n'.join(['  a    b    c',
-                          '---  ---  ---',
-                          '  0    1    2',
-                          '  0    1    2',
-                          '  0    1    2'])
+    expected = "\n".join(
+        [
+            "  a    b    c",
+            "---  ---  ---",
+            "  0    1    2",
+            "  0    1    2",
+            "  0    1    2",
+        ]
+    )
     print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
     assert_equal(expected, formatted)
 
@@ -63,13 +79,18 @@ def test_iter_of_iters_with_headers():
 def test_datetime_values():
     "Regression: datetime, date, and time values in cells (issue #10)."
     import datetime
-    dt = datetime.datetime(1991,2,19,17,35,26)
-    d = datetime.date(1991,2,19)
-    t = datetime.time(17,35,26)
+
+    dt = datetime.datetime(1991, 2, 19, 17, 35, 26)
+    d = datetime.date(1991, 2, 19)
+    t = datetime.time(17, 35, 26)
     formatted = tabulate([[dt, d, t]])
-    expected = '\n'.join(['-------------------  ----------  --------',
-                          '1991-02-19 17:35:26  1991-02-19  17:35:26',
-                          '-------------------  ----------  --------'])
+    expected = "\n".join(
+        [
+            "-------------------  ----------  --------",
+            "1991-02-19 17:35:26  1991-02-19  17:35:26",
+            "-------------------  ----------  --------",
+        ]
+    )
     print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
     assert_equal(expected, formatted)
 
@@ -77,8 +98,9 @@ def test_datetime_values():
 def test_simple_separated_format():
     "Regression: simple_separated_format() accepts any separator (issue #12)"
     from tabulate import simple_separated_format
+
     fmt = simple_separated_format("!")
-    expected = 'spam!eggs'
+    expected = "spam!eggs"
     formatted = tabulate([["spam", "eggs"]], tablefmt=fmt)
     print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
     assert_equal(expected, formatted)
@@ -87,22 +109,27 @@ def test_simple_separated_format():
 def py3test_require_py3():
     "Regression: py33 tests should actually use Python 3 (issue #13)"
     from platform import python_version_tuple
+
     print("Expected Python version: 3.x.x")
     print("Python version used for tests: %s.%s.%s" % python_version_tuple())
-    assert_equal(python_version_tuple()[0], '3')
+    assert_equal(python_version_tuple()[0], "3")
 
 
 def test_simple_separated_format_with_headers():
     "Regression: simple_separated_format() on tables with headers (issue #15)"
     from tabulate import simple_separated_format
-    expected = '  a|  b\n  1|  2'
-    formatted = tabulate([[1,2]], headers=["a", "b"], tablefmt=simple_separated_format("|"))
+
+    expected = "  a|  b\n  1|  2"
+    formatted = tabulate(
+        [[1, 2]], headers=["a", "b"], tablefmt=simple_separated_format("|")
+    )
     assert_equal(expected, formatted)
 
 
 def test_column_type_of_bytestring_columns():
     "Regression: column type for columns of bytestrings (issue #16)"
     from tabulate import _column_type, _binary_type
+
     result = _column_type([b"foo", b"bar"])
     expected = _binary_type
     assert_equal(result, expected)
@@ -110,88 +137,81 @@ def test_column_type_of_bytestring_columns():
 
 def test_numeric_column_headers():
     "Regression: numbers as column headers (issue #22)"
-    result = tabulate([[1],[2]], [42])
-    expected = '  42\n----\n   1\n   2'
+    result = tabulate([[1], [2]], [42])
+    expected = "  42\n----\n   1\n   2"
     assert_equal(result, expected)
 
-    lod = [dict((p,i) for p in range(5)) for i in range(5)]
+    lod = [dict((p, i) for p in range(5)) for i in range(5)]
     result = tabulate(lod, "keys")
-    expected = "\n".join([
-        "  0    1    2    3    4",
-        "---  ---  ---  ---  ---",
-        "  0    0    0    0    0",
-        "  1    1    1    1    1",
-        "  2    2    2    2    2",
-        "  3    3    3    3    3",
-        "  4    4    4    4    4",])
+    expected = "\n".join(
+        [
+            "  0    1    2    3    4",
+            "---  ---  ---  ---  ---",
+            "  0    0    0    0    0",
+            "  1    1    1    1    1",
+            "  2    2    2    2    2",
+            "  3    3    3    3    3",
+            "  4    4    4    4    4",
+        ]
+    )
     assert_equal(result, expected)
 
 
 def test_88_256_ANSI_color_codes():
     "Regression: color codes for terminals with 88/256 colors (issue #26)"
-    colortable = [('\x1b[48;5;196mred\x1b[49m',
-                   '\x1b[38;5;196mred\x1b[39m')]
-    colorlessheaders = ('background', 'foreground')
-    formatted = tabulate(colortable, colorlessheaders, 'pipe')
-    expected = "\n".join([
-        '| background   | foreground   |',
-        '|:-------------|:-------------|',
-        '| \x1b[48;5;196mred\x1b[49m          | \x1b[38;5;196mred\x1b[39m          |'])
+    colortable = [("\x1b[48;5;196mred\x1b[49m", "\x1b[38;5;196mred\x1b[39m")]
+    colorlessheaders = ("background", "foreground")
+    formatted = tabulate(colortable, colorlessheaders, "pipe")
+    expected = "\n".join(
+        [
+            "| background   | foreground   |",
+            "|:-------------|:-------------|",
+            "| \x1b[48;5;196mred\x1b[49m          | \x1b[38;5;196mred\x1b[39m          |",
+        ]
+    )
     print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
     assert_equal(expected, formatted)
 
 
 def test_column_with_mixed_value_types():
     "Regression: mixed value types in the same column (issue #31)"
-    expected = '\n'.join([
-        '-----',
-        '',
-        'a',
-        'я',
-        '0',
-        'False',
-        '-----',
-    ])
-    data = [[None], ['a'], ['\u044f'], [0], [False]]
+    expected = "\n".join(["-----", "", "a", "я", "0", "False", "-----"])
+    data = [[None], ["a"], ["\u044f"], [0], [False]]
     table = tabulate(data)
     assert_equal(table, expected)
 
 
 def test_latex_escape_special_chars():
     "Regression: escape special characters in LaTeX output (issue #32)"
-    expected = "\n".join([
-        r'\begin{tabular}{l}',
-        r'\hline',
-        r' foo\^{}bar     \\',
-        r'\hline',
-        r' \&\%\^{}\_\$\#\{\}\ensuremath{<}\ensuremath{>}\textasciitilde{} \\',
-        r'\hline',
-        r'\end{tabular}'])
+    expected = "\n".join(
+        [
+            r"\begin{tabular}{l}",
+            r"\hline",
+            r" foo\^{}bar     \\",
+            r"\hline",
+            r" \&\%\^{}\_\$\#\{\}\ensuremath{<}\ensuremath{>}\textasciitilde{} \\",
+            r"\hline",
+            r"\end{tabular}",
+        ]
+    )
     result = tabulate([["&%^_$#{}<>~"]], ["foo^bar"], tablefmt="latex")
     assert_equal(result, expected)
 
 
 def test_isconvertible_on_set_values():
     "Regression: don't fail with TypeError on set values (issue #35)"
-    expected_py2 = "\n".join([
-        'a    b',
-        '---  -------',
-        'Foo  set([])',])
-    expected_py3 = "\n".join([
-        'a    b',
-        '---  -----',
-        'Foo  set()',])
-    result = tabulate([["Foo",set()]], headers=["a","b"])
+    expected_py2 = "\n".join(["a    b", "---  -------", "Foo  set([])"])
+    expected_py3 = "\n".join(["a    b", "---  -----", "Foo  set()"])
+    result = tabulate([["Foo", set()]], headers=["a", "b"])
     assert_in(result, [expected_py2, expected_py3])
 
 
 def test_ansi_color_for_decimal_numbers():
     "Regression: ANSI colors for decimal numbers (issue #36)"
     table = [["Magenta", "\033[95m" + "1.1" + "\033[0m"]]
-    expected = "\n".join([
-        '-------  ---',
-        'Magenta  \x1b[95m1.1\x1b[0m',
-        '-------  ---'])
+    expected = "\n".join(
+        ["-------  ---", "Magenta  \x1b[95m1.1\x1b[0m", "-------  ---"]
+    )
     result = tabulate(table)
     assert_equal(result, expected)
 
@@ -201,9 +221,7 @@ def test_alignment_of_decimal_numbers_with_ansi_color():
     v1 = "\033[95m" + "12.34" + "\033[0m"
     v2 = "\033[95m" + "1.23456" + "\033[0m"
     table = [[v1], [v2]]
-    expected = "\n".join([
-        '\x1b[95m12.34\x1b[0m',
-        ' \x1b[95m1.23456\x1b[0m'])
+    expected = "\n".join(["\x1b[95m12.34\x1b[0m", " \x1b[95m1.23456\x1b[0m"])
     result = tabulate(table, tablefmt="plain")
     assert_equal(result, expected)
 
@@ -220,13 +238,16 @@ def test_colorclass_colors():
     "Regression: ANSI colors in a unicode/str subclass (issue #49)"
     try:
         import colorclass
+
         s = colorclass.Color("{magenta}3.14{/magenta}")
         result = tabulate([[s]], tablefmt="plain")
         expected = "\x1b[35m3.14\x1b[39m"
         assert_equal(result, expected)
     except ImportError:
+
         class textclass(_text_type):
             pass
+
         s = textclass("\x1b[35m3.14\x1b[39m")
         result = tabulate([[s]], tablefmt="plain")
         expected = "\x1b[35m3.14\x1b[39m"
@@ -236,16 +257,20 @@ def test_colorclass_colors():
 def test_mix_normal_and_wide_characters():
     "Regression: wide characters in a grid format (issue #51)"
     try:
-        import wcwidth
-        ru_text = '\u043f\u0440\u0438\u0432\u0435\u0442'
-        cn_text = '\u4f60\u597d'
+        import wcwidth  # noqa
+
+        ru_text = "\u043f\u0440\u0438\u0432\u0435\u0442"
+        cn_text = "\u4f60\u597d"
         result = tabulate([[ru_text], [cn_text]], tablefmt="grid")
-        expected = "\n".join([
-            '+--------+',
-            '| \u043f\u0440\u0438\u0432\u0435\u0442 |',
-            '+--------+',
-            '| \u4f60\u597d   |',
-            '+--------+'])
+        expected = "\n".join(
+            [
+                "+--------+",
+                "| \u043f\u0440\u0438\u0432\u0435\u0442 |",
+                "+--------+",
+                "| \u4f60\u597d   |",
+                "+--------+",
+            ]
+        )
         assert_equal(result, expected)
     except ImportError:
         print("test_mix_normal_and_wide_characters is skipped (requires wcwidth lib)")
@@ -256,8 +281,7 @@ def test_align_long_integers():
     "Regression: long integers should be aligned as integers (issue #61)"
     table = [[_long_type(1)], [_long_type(234)]]
     result = tabulate(table, tablefmt="plain")
-    expected = "\n".join(["  1",
-                          "234"])
+    expected = "\n".join(["  1", "234"])
     assert_equal(result, expected)
 
 
@@ -265,6 +289,7 @@ def test_numpy_array_as_headers():
     "Regression: NumPy array used as headers (issue #62)"
     try:
         import numpy as np
+
         headers = np.array(["foo", "bar"])
         result = tabulate([], headers, tablefmt="plain")
         expected = "foo    bar"
@@ -276,8 +301,7 @@ def test_numpy_array_as_headers():
 def test_boolean_columns():
     "Regression: recognize boolean columns (issue #64)"
     xortable = [[False, True], [True, False]]
-    expected = "\n".join(["False  True",
-                          "True   False"])
+    expected = "\n".join(["False  True", "True   False"])
     result = tabulate(xortable, tablefmt="plain")
     assert_equal(result, expected)
 
@@ -286,14 +310,17 @@ def test_ansi_color_bold_and_fgcolor():
     "Regression: set ANSI color and bold face together (issue #65)"
     table = [["1", "2", "3"], ["4", "\x1b[1;31m5\x1b[1;m", "6"], ["7", "8", "9"]]
     result = tabulate(table, tablefmt="grid")
-    expected = "\n".join([
-        u'+---+---+---+',
-        u'| 1 | 2 | 3 |',
-        u'+---+---+---+',
-        u'| 4 | \x1b[1;31m5\x1b[1;m | 6 |',
-        u'+---+---+---+',
-        u'| 7 | 8 | 9 |',
-        u'+---+---+---+'])
+    expected = "\n".join(
+        [
+            "+---+---+---+",
+            "| 1 | 2 | 3 |",
+            "+---+---+---+",
+            "| 4 | \x1b[1;31m5\x1b[1;m | 6 |",
+            "+---+---+---+",
+            "| 7 | 8 | 9 |",
+            "+---+---+---+",
+        ]
+    )
     assert_equal(result, expected)
 
 
@@ -308,26 +335,24 @@ def test_escape_empty_cell_in_first_column_in_rst():
     "Regression: escape empty cells of the first column in RST format (issue #82)"
     table = [["foo", 1], ["", 2], ["bar", 3]]
     headers = ["", "val"]
-    expected = "\n".join([
-        u"====  =====",
-        u"..      val",
-        u"====  =====",
-        u"foo       1",
-        u"..        2",
-        u"bar       3",
-        u"====  ====="])
+    expected = "\n".join(
+        [
+            "====  =====",
+            "..      val",
+            "====  =====",
+            "foo       1",
+            "..        2",
+            "bar       3",
+            "====  =====",
+        ]
+    )
     result = tabulate(table, headers, tablefmt="rst")
     assert_equal(result, expected)
 
 
 def test_ragged_rows():
     "Regression: allow rows with different number of columns (issue #85)"
-    table = [[1,2,3], [1,2], [1,2,3,4]]
-    expected = "\n".join([
-        u"-  -  -  -",
-        u"1  2  3",
-        u"1  2",
-        u"1  2  3  4",
-        u"-  -  -  -"])
+    table = [[1, 2, 3], [1, 2], [1, 2, 3, 4]]
+    expected = "\n".join(["-  -  -  -", "1  2  3", "1  2", "1  2  3  4", "-  -  -  -"])
     result = tabulate(table)
     assert_equal(result, expected)

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,17 @@
 # for testing and it is disabled by default.
 
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = lint, py27, py33, py34, py35, py36
 
 [testenv]
 commands = nosetests -v --with-doctest test/ tabulate.py
 deps =
     nose
 
+[testenv:lint]
+commands = python -m pre_commit run -a
+deps =
+    pre-commit
 
 [testenv:py27-extra]
 basepython = python2.7
@@ -81,3 +85,8 @@ deps =
     numpy
     pandas
     wcwidth
+
+[flake8]
+max-complexity = 22
+max-line-length = 99
+ignore = E203, W503, C901, E402, B011


### PR DESCRIPTION
This should make very easy to enable additional linters without having
to change CI jobs or the way user lints.

Configuration is mostly copied from tox project itself, with few
removals.

Related: #3 