### PR TITLE
Add an option to add a title for table

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ This optional argument for title allows users to print out a title at
 the center above the table so that it is easy for users to verify the table.
 
     >>> print(tabulate(table, headers, tablefmt="simple", title="Receipts"))
-       Receipts  
+       Receipts
     item      qty
     ------  -----
     eggs      451

--- a/README.md
+++ b/README.md
@@ -604,6 +604,19 @@ a multiline cell, and headers with a multiline cell:
 
 Multiline cells are not well supported for the other table formats.
 
+### Title
+
+This optional argument for title allows users to print out a title at
+the center above the table so that it is easy for users to verify the table.
+
+    >>> print(tabulate(table, headers, tablefmt="simple", title="Receipts"))
+       Receipts  
+    item      qty
+    ------  -----
+    eggs      451
+    more       42
+    spam
+
 Usage of the command line utility
 ---------------------------------
 

--- a/tabulate.py
+++ b/tabulate.py
@@ -1109,7 +1109,6 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
 
 def tabulate(
     tabular_data,
-    title="",
     headers=(),
     tablefmt="simple",
     floatfmt=_DEFAULT_FLOATFMT,
@@ -1119,6 +1118,7 @@ def tabulate(
     showindex="default",
     disable_numparse=False,
     colalign=None,
+    title="",
 ):
     """Format a fixed width table for pretty printing.
 
@@ -1486,7 +1486,9 @@ def tabulate(
     if not isinstance(tablefmt, TableFormat):
         tablefmt = _table_formats.get(tablefmt, _table_formats["simple"])
 
-    return _format_table(tablefmt, title, headers, rows, minwidths, aligns, is_multiline)
+    return _format_table(
+        tablefmt, title, headers, rows, minwidths, aligns, is_multiline
+    )
 
 
 def _expand_numparse(disable_numparse, column_count):
@@ -1652,7 +1654,16 @@ def _main():
         opts, args = getopt.getopt(
             sys.argv[1:],
             "h1o:s:F:A:f:t:",
-            ["help", "header", "output", "sep=", "float=", "align=", "format=", "title"],
+            [
+                "help",
+                "header",
+                "output",
+                "sep=",
+                "float=",
+                "align=",
+                "format=",
+                "title",
+            ],
         )
     except getopt.GetoptError as e:
         print(e)
@@ -1721,7 +1732,9 @@ def _pprint_file(fobject, title, headers, tablefmt, sep, floatfmt, file, colalig
     rows = fobject.readlines()
     table = [re.split(sep, r.rstrip()) for r in rows if r.strip()]
     print(
-        tabulate(table, title, headers, tablefmt, floatfmt=floatfmt, colalign=colalign),
+        tabulate(
+            table, headers, tablefmt, floatfmt=floatfmt, colalign=colalign, title=title
+        ),
         file=file,
     )
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1387,3 +1387,19 @@ def test_preserve_whitespace():
     expected = "\n".join(["h1    h2    h3", "----  ----  ----", "foo   bar   foo"])
     result = tabulate(test_table, table_headers)
     assert_equal(expected, result)
+
+
+def test_display_title():
+    "Output: A table with a title at the center, above of the table"
+    expected = "\n".join(
+        [
+            "      Receipts      ",
+            "strings      numbers",
+            "spam         41.9999",
+            "eggs        451",
+        ]
+    )
+    result = tabulate(
+        _test_table, _test_table_headers, tablefmt="plain", title="Receipts"
+    )
+    assert_equal(expected, result)


### PR DESCRIPTION
Users can add a title to appear above the table as an option.
Title appears at the center above the table.

>>> python3 tabulate.py -1 -t "Grocery Receipt" -f psql sample.txt
      Grocery Receipt
+--------+-------+---------+
| item   |   qty |   price |
|--------+-------+---------|
| spam   |     3 |    4.99 |
| eggs   |     2 |    8.99 |
| bacon  |     1 |    6.49 |
+--------+-------+---------+

>>> python3 tabulate.py -1 -f psql sample.txt
+--------+-------+---------+
| item   |   qty |   price |
|--------+-------+---------|
| spam   |     3 |    4.99 |
| eggs   |     2 |    8.99 |
| bacon  |     1 |    6.49 |
+--------+-------+---------+