### PR TITLE
Added proxy related vars to passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,10 @@ envlist = lint, py27, py35, py36, py37
 commands = nosetests -v --with-doctest test/ tabulate.py
 deps =
     nose
+passenv =
+    CURL_CA_BUNDLE
+    REQUESTS_CA_BUNDLE
+    SSL_CERT_FILE
 
 [testenv:lint]
 commands = python -m pre_commit run -a


### PR DESCRIPTION
Not passing these vars can prevent testing tools from running on systems
that do have http proxies.