### PR TITLE
Fixes #20 - allow custom user specified TableFormats

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -1423,7 +1423,11 @@ def tabulate(
 
     has_invisible = re.search(_invisible_codes, plain_text)
     enable_widechars = wcwidth is not None and WIDE_CHARS_MODE
-    if tablefmt in multiline_formats and _is_multiline(plain_text):
+    if (
+        not isinstance(tablefmt, TableFormat)
+        and tablefmt in multiline_formats
+        and _is_multiline(plain_text)
+    ):
         tablefmt = multiline_formats.get(tablefmt, tablefmt)
         is_multiline = True
     else:

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function
 from __future__ import unicode_literals
-from tabulate import tabulate, _text_type, _long_type
+from tabulate import tabulate, _text_type, _long_type, TableFormat, Line, DataRow
 from common import assert_equal, assert_in, SkipTest
 
 
@@ -364,4 +364,22 @@ def test_empty_pipe_table_with_columns():
     headers = ["Col1", "Col2"]
     expected = "\n".join(["| Col1   | Col2   |", "|--------|--------|"])
     result = tabulate(table, headers, tablefmt="pipe")
+    assert_equal(result, expected)
+
+
+def test_custom_tablefmt():
+    "Regression: allow custom TableFormat that specifies with_header_hide (github issue #20)"
+    tablefmt = TableFormat(
+        lineabove=Line("", "-", "  ", ""),
+        linebelowheader=Line("", "-", "  ", ""),
+        linebetweenrows=None,
+        linebelow=Line("", "-", "  ", ""),
+        headerrow=DataRow("", "  ", ""),
+        datarow=DataRow("", "  ", ""),
+        padding=0,
+        with_header_hide=["lineabove", "linebelow"],
+    )
+    rows = [["foo", "bar"], ["baz", "qux"]]
+    expected = "\n".join(["A    B", "---  ---", "foo  bar", "baz  qux"])
+    result = tabulate(rows, headers=["A", "B"], tablefmt=tablefmt)
     assert_equal(result, expected)


### PR DESCRIPTION
Check that tablefmt is not a TableFormat object before checking if it is
multiline.  If it is a custom user-specified TableFormat, leave it
alone.