### PR TITLE
Add `pretty` format to behave like PrettyTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Supported table formats are:
 -   "orgtbl"
 -   "jira"
 -   "presto"
+-   "pretty"
 -   "psql"
 -   "rst"
 -   "mediawiki"
@@ -220,6 +221,18 @@ corresponds to the `pipe` format without alignment colons:
      spam   |    42
      eggs   |   451
      bacon  |     0
+
+`pretty` attempts to be close to the format emitted by the PrettyTables
+library:
+
+    >>> print(tabulate(table, headers, tablefmt="pretty"))
+    +-------+-----+
+    | item  | qty |
+    +-------+-----+
+    | spam  | 42  |
+    | eggs  | 451 |
+    | bacon |  0  |
+    +-------+-----+
 
 `psql` is like tables formatted by Postgres' psql cli:
 
@@ -577,6 +590,18 @@ a multiline cell, and headers with a multiline cell:
      eggs   |   451
      more   |    42
      spam   |
+
+`pretty` tables:
+
+    >>> print(tabulate(table, headers, tablefmt="pretty"))
+    +------+-----+
+    | item | qty |
+    | name |     |
+    +------+-----+
+    | eggs | 451 |
+    | more | 42  |
+    | spam |     |
+    +------+-----+
 
 `psql` tables:
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -700,6 +700,112 @@ def test_psql_multiline_with_empty_cells_headerless():
     assert_equal(expected, result)
 
 
+def test_pretty():
+    "Output: pretty with headers"
+    expected = "\n".join(
+        [
+            "+---------+---------+",
+            "| strings | numbers |",
+            "+---------+---------+",
+            "|  spam   | 41.9999 |",
+            "|  eggs   |  451.0  |",
+            "+---------+---------+",
+        ]
+    )
+    result = tabulate(_test_table, _test_table_headers, tablefmt="pretty")
+    assert_equal(expected, result)
+
+
+def test_pretty_headerless():
+    "Output: pretty without headers"
+    expected = "\n".join(
+        [
+            "+------+---------+",
+            "| spam | 41.9999 |",
+            "| eggs |  451.0  |",
+            "+------+---------+",
+        ]
+    )
+    result = tabulate(_test_table, tablefmt="pretty")
+    assert_equal(expected, result)
+
+
+def test_pretty_multiline_headerless():
+    "Output: pretty with multiline cells without headers"
+    table = [["foo bar\nbaz\nbau", "hello"], ["", "multiline\nworld"]]
+    expected = "\n".join(
+        [
+            "+---------+-----------+",
+            "| foo bar |   hello   |",
+            "|   baz   |           |",
+            "|   bau   |           |",
+            "|         | multiline |",
+            "|         |   world   |",
+            "+---------+-----------+",
+        ]
+    )
+    result = tabulate(table, tablefmt="pretty")
+    assert_equal(expected, result)
+
+
+def test_pretty_multiline():
+    "Output: pretty with multiline cells with headers"
+    table = [[2, "foo\nbar"]]
+    headers = ("more\nspam \x1b[31meggs\x1b[0m", "more spam\n& eggs")
+    expected = "\n".join(
+        [
+            "+-----------+-----------+",
+            "|   more    | more spam |",
+            "| spam \x1b[31meggs\x1b[0m |  & eggs   |",
+            "+-----------+-----------+",
+            "|     2     |    foo    |",
+            "|           |    bar    |",
+            "+-----------+-----------+",
+        ]
+    )
+    result = tabulate(table, headers, tablefmt="pretty")
+    assert_equal(expected, result)
+
+
+def test_pretty_multiline_with_empty_cells():
+    "Output: pretty with multiline cells and empty cells with headers"
+    table = [
+        ["hdr", "data", "fold"],
+        ["1", "", ""],
+        ["2", "very long data", "fold\nthis"],
+    ]
+    expected = "\n".join(
+        [
+            "+-----+----------------+------+",
+            "| hdr |      data      | fold |",
+            "+-----+----------------+------+",
+            "|  1  |                |      |",
+            "|  2  | very long data | fold |",
+            "|     |                | this |",
+            "+-----+----------------+------+",
+        ]
+    )
+    result = tabulate(table, headers="firstrow", tablefmt="pretty")
+    assert_equal(expected, result)
+
+
+def test_pretty_multiline_with_empty_cells_headerless():
+    "Output: pretty with multiline cells and empty cells without headers"
+    table = [["0", "", ""], ["1", "", ""], ["2", "very long data", "fold\nthis"]]
+    expected = "\n".join(
+        [
+            "+---+----------------+------+",
+            "| 0 |                |      |",
+            "| 1 |                |      |",
+            "| 2 | very long data | fold |",
+            "|   |                | this |",
+            "+---+----------------+------+",
+        ]
+    )
+    result = tabulate(table, tablefmt="pretty")
+    assert_equal(expected, result)
+
+
 def test_jira():
     "Output: jira with headers"
     expected = "\n".join(


### PR DESCRIPTION
This adds a new `pretty` default TableFormat to make it easy to convert
legacy code using the PrettyTables library over to using tabulate.

It does not provide 100% output compatibility, but it does address many
of the differences between PrettyTable's output and the closest existing
one of psql. This will help minimize the impact in unit tests and
expected user output for projects to make the switch.