### PR TITLE
ENH: return a wrapped str w/ a _repr_html_ so that Jupyter displays the html

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ MediaWiki-based sites:
 
 `html` produces standard HTML markup as an html.escape'd str
 with a ._repr_html_ method so that Jupyter Lab and Notebook display the HTML
-and a .str method so that the raw HTML remains accessible:
+and a .str property so that the raw HTML remains accessible:
 
     >>> print(tabulate(table, headers, tablefmt="html"))
     <table>

--- a/README.md
+++ b/README.md
@@ -319,7 +319,9 @@ MediaWiki-based sites:
     |<. eggs    |>.   451 |
     |<. bacon   |>.     0 |
 
-`html` produces standard HTML markup:
+`html` produces standard HTML markup as an html.escape'd str
+with a ._repr_html_ method so that Jupyter Lab and Notebook display the HTML
+and a .str method so that the raw HTML remains accessible:
 
     >>> print(tabulate(table, headers, tablefmt="html"))
     <table>
@@ -714,4 +716,5 @@ naught101, John Vandenberg, Zack Dever, Christian Clauss, Benjamin
 Maier, Andy MacKinlay, Thomas Roten, Jue Wang, Joe King, Samuel Phan,
 Nick Satterly, Daniel Robbins, Dmitry B, Lars Butler, Andreas Maier,
 Dick Marinus, Sébastien Celles, Yago González, Andrew Gaul, Wim Glenn,
-Jean Michel Rouly, Tim Gates, John Vandenberg, Sorin Sbarnea.
+Jean Michel Rouly, Tim Gates, John Vandenberg, Sorin Sbarnea,
+Wes Turner.

--- a/tabulate.py
+++ b/tabulate.py
@@ -1344,7 +1344,7 @@ def tabulate(
 
     "html" produces HTML markup as an html.escape'd str
     with a ._repr_html_ method so that Jupyter Lab and Notebook display the HTML
-    and a .str method so that the raw HTML remains accessible:
+    and a .str property so that the raw HTML remains accessible:
 
     >>> print(tabulate([["strings", "numbers"], ["spam", 41.9999], ["eggs", "451.0"]],
     ...                headers="firstrow", tablefmt="html"))
@@ -1584,8 +1584,9 @@ class JupyterHTMLStr(str):
     def _repr_html_(self):
         return self
 
+    @property
     def str(self):
-        """add a .str method so that the raw string is still accessible"""
+        """add a .str property so that the raw string is still accessible"""
         return self
 
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -914,6 +914,8 @@ def test_html():
     )
     result = tabulate(_test_table, _test_table_headers, tablefmt="html")
     assert_equal(expected, result)
+    assert hasattr(result, '_repr_html_')
+    assert result._repr_html_() == result.str
 
 
 def test_html_headerless():
@@ -930,6 +932,8 @@ def test_html_headerless():
     )
     result = tabulate(_test_table, tablefmt="html")
     assert_equal(expected, result)
+    assert hasattr(result, '_repr_html_')
+    assert result._repr_html_() == result.str
 
 
 def test_latex():


### PR DESCRIPTION
Usage:

```python
from tabulate import tabulate
tabulate(data, output='html')
```

To access the raw HTML string in Jupyter:
```python
from tabulate import tabulate
tabulate(data, output='html').str
```

IDK if this needs to be in the docs? I added notes in the README there