### PR TITLE
Put absolute path of CHANGELOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ was run in Python 3.6.8 on Ubuntu 18.04 in WSL:
 Version history
 ---------------
 
-The full version history can be found at the [changelog](./CHANGELOG).
+The full version history can be found at the [changelog](https://github.com/astanin/python-tabulate/blob/master/CHANGELOG).
 
 How to contribute
 -----------------


### PR DESCRIPTION
closes #29 

Have added absolute path so that link works when viewing project on PyPI