### PR TITLE
benchmark: remove redundant assignment and double import

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -8,7 +8,7 @@ import prettytable
 import texttable
 import sys
 import codecs
-from platform import python_version_tuple, platform
+from platform import python_version_tuple
 
 setup_code = r"""
 from csv import writer
@@ -107,6 +107,8 @@ def benchmark(n):
     table = tabulate.tabulate(
         results, ["Table formatter", "time, μs", "rel. time"], "rst", floatfmt=".1f"
     )
+
+    from platform import platform
 
     if platform().startswith("Windows"):
         print(table)

--- a/benchmark.py
+++ b/benchmark.py
@@ -8,7 +8,7 @@ import prettytable
 import texttable
 import sys
 import codecs
-from platform import python_version_tuple
+from platform import python_version_tuple, platform
 
 setup_code = r"""
 from csv import writer
@@ -96,8 +96,6 @@ def benchmark(n):
     global methods
     if "--onlyself" in sys.argv[1:]:
         methods = [m for m in methods if m[0].startswith("tabulate")]
-    else:
-        methods = methods
 
     results = [
         (desc, timeit(code, setup_code, number=n) / n * 1e6) for desc, code in methods
@@ -110,9 +108,7 @@ def benchmark(n):
         results, ["Table formatter", "time, μs", "rel. time"], "rst", floatfmt=".1f"
     )
 
-    import platform
-
-    if platform.platform().startswith("Windows"):
+    if platform().startswith("Windows"):
         print(table)
     elif python_version_tuple()[0] < "3":
         print(codecs.encode(table, "utf-8"))


### PR DESCRIPTION
Changes in `benchmark.py`.

Assigning `methods = methods` is redundant.
Module `platform` was imported with both `import` and `import from`, merged into one `import from`.