### PR TITLE
Recognize numbers with comma separators

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -582,8 +582,16 @@ def _isnumber(string):
     False
     >>> _isnumber("inf")
     True
+    >>> _isnumber("1,234.56")
+    True
+    >>> _isnumber("1,234,578.0")
+    True
     """
-    if not _isconvertible(float, string):
+    if isinstance(string, (_text_type)) and "," in string and (
+        _isconvertible(float, string.replace(",",""))
+    ):
+        return True
+    elif not _isconvertible(float, string):
         return False
     elif isinstance(string, (_text_type, _binary_type)) and (
         math.isinf(float(string)) or math.isnan(float(string))


### PR DESCRIPTION
With the `floatfmt=',.2f'`, the tabulate is not recognizing the number as a number.  I believe the commas is an issue for the number detection code.

An illustrative example:
```
>>> stuff={"first": ["c1r1", "c1r2"], "second": [14502.05, 105]}
>>> print(tabulate(stuff, tablefmt="grid", floatfmt=',.2f'))
+------+--------------+
| c1r1 | 14,502.05    |
+------+--------------+
| c1r2 |       105.00 |
+------+--------------+
```

Expected output:
```
+------+--------------+
| c1r1 |    14,502.05 |
+------+--------------+
| c1r2 |       105.00 |
+------+--------------+
```

This pull request changes the `_isnumber` function to recognize strings with commas, which without the commas parse as floats.