### PR TITLE
Support List of UserDicts (or other dict-like objects)

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -1058,8 +1058,8 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
         ):
             # namedtuple
             headers = list(map(_text_type, rows[0]._fields))
-        elif len(rows) > 0 and isinstance(rows[0], dict):
-            # dict or OrderedDict
+        elif len(rows) > 0 and hasattr(rows[0], "keys") and hasattr(rows[0], "values"):
+            # dict-like object
             uniq_keys = set()  # implements hashed lookup
             keys = []  # storage for set
             if headers == "firstrow":

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -6,7 +6,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from tabulate import tabulate
 from common import assert_equal, assert_in, raises, skip
-from collections import UserDict
+try:
+    from collections import UserDict
+except ImportError:
+    # Python2
+    from UserDict import UserDict
 
 
 def test_iterable_of_iterables():

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from tabulate import tabulate
 from common import assert_equal, assert_in, raises, skip
+from collections import UserDict
 
 
 def test_iterable_of_iterables():
@@ -377,6 +378,13 @@ def test_list_of_dicts():
     result = tabulate(lod)
     assert_in(result, [expected1, expected2])
 
+def test_list_of_userdicts():
+    "Input: a list of UserDicts."
+    lod = [UserDict(foo=1, bar=2), UserDict(foo=3, bar=4)]
+    expected1 = "\n".join(["-  -", "1  2", "3  4", "-  -"])
+    expected2 = "\n".join(["-  -", "2  1", "4  3", "-  -"])
+    result = tabulate(lod)
+    assert_in(result, [expected1, expected2])
 
 def test_list_of_dicts_keys():
     "Input: a list of dictionaries, with keys as headers."
@@ -390,6 +398,17 @@ def test_list_of_dicts_keys():
     result = tabulate(lod, headers="keys")
     assert_in(result, [expected1, expected2])
 
+def test_list_of_userdicts_keys():
+    "Input: a list of UserDicts."
+    lod = [UserDict(foo=1, bar=2), UserDict(foo=3, bar=4)]
+    expected1 = "\n".join(
+        ["  foo    bar", "-----  -----", "    1      2", "    3      4"]
+    )
+    expected2 = "\n".join(
+        ["  bar    foo", "-----  -----", "    2      1", "    4      3"]
+    )
+    result = tabulate(lod, headers="keys")
+    assert_in(result, [expected1, expected2])
 
 def test_list_of_dicts_with_missing_keys():
     "Input: a list of dictionaries, with missing keys."


### PR DESCRIPTION
Hi,

At the moment `_normalize_tabular_data` does not correctly recognise lists of UserDicts (or other dict-like objects) as it uses `isinstance(rows[0], dict)`. This patch switches the test to use `hasattr` instead and adds unit tests. 

Regards, Paul