### PR TITLE
Fix a bug that header shifts wrongly when do tabulate(headers='keys', showindex=False) for pandas DataFrame with named index

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -1022,7 +1022,7 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
         elif hasattr(tabular_data, "index"):
             # values is a property, has .index => it's likely a pandas.DataFrame (pandas 0.11.0)
             keys = list(tabular_data)
-            if tabular_data.index.name is not None:
+            if showindex in ["default", "always", True] and tabular_data.index.name is not None:
                 if isinstance(tabular_data.index.name, list):
                     keys[:0] = tabular_data.index.name
                 else:

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1363,7 +1363,8 @@ def test_pandas_without_index():
         import pandas
 
         df = pandas.DataFrame(
-            [["one", 1], ["two", None]], columns=["string", "number"], index=["a", "b"]
+            [["one", 1], ["two", None]], columns=["string", "number"],
+            index=pandas.Index(["a", "b"], name="index")
         )
         expected = "\n".join(
             [


### PR DESCRIPTION
Fix #97 