### PR TITLE
Strip hyperlinks from text

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -729,7 +729,7 @@ def _padnone(ignore_width, s):
 def _strip_invisible(s):
     r"""Remove invisible ANSI color codes.
 
-    >>> _strip_invisible('\x1B]8;;https://example.com\x1B\\This is a link\x1B]8;;\x1B\\')
+    >>> str(_strip_invisible('\x1B]8;;https://example.com\x1B\\This is a link\x1B]8;;\x1B\\'))
     'This is a link'
 
     """


### PR DESCRIPTION
This strips terminal hyperlinks from text when stripping invisible characters. Without doing this, the wcwidth.wcswidth() function returns `-1` and the column widths aren't correct.

The escape sequence for hyperlinks is described here:
https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda#the-escape-sequence

```python3
import tabulate

print(tabulate.tabulate((
    ['foo', 'This is a link', 'bar'],
    ['bar', 'This is also a link', 'baz'])))

print(tabulate.tabulate((
    ['foo', '\x1B]8;;https://example.com\x1B\\This is a link\x1B]8;;\x1B\\', 'bar'],
    ['bar', '\x1B]8;;https://github.com/astanin/python-tabulate\x1B\\This is also a link\x1B]8;;\x1B\\', 'baz'])))
```

Before this PR

```
---  -------------------  ---
foo  This is a link       bar
bar  This is also a link  baz
---  -------------------  ---
---    ---
foo  This is a link   bar
bar  This is also a link   baz
---    ---
```


With this PR

```
---  -------------------  ---
foo  This is a link       bar
bar  This is also a link  baz
---  -------------------  ---
---  -------------------  ---
foo  This is a link       bar
bar  This is also a link  baz
---  -------------------  ---
```