### PR TITLE
Revert "Recognize numbers with comma separators"

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -610,16 +610,8 @@ def _isnumber(string):
     False
     >>> _isnumber("inf")
     True
-    >>> _isnumber("1,234.56")
-    True
-    >>> _isnumber("1,234,578.0")
-    True
     """
-    if isinstance(string, (_text_type)) and "," in string and (
-        _isconvertible(float, string.replace(",",""))
-    ):
-        return True
-    elif not _isconvertible(float, string):
+    if not _isconvertible(float, string):
         return False
     elif isinstance(string, (_text_type, _binary_type)) and (
         math.isinf(float(string)) or math.isnan(float(string))


### PR DESCRIPTION
Reverts astanin/python-tabulate#51

This change has caused issues in Python 3 when floatfmt is not specified, but there's text with digits and comma in between.
I think this feature have to be re-implemented, and take care of the following use cases:

- if floatfmt with a grouping option ("_" or ",") is not specified, do not consider "123,456" to be a number
- if a grouping option is specified, parse numbers accordingly

Additional tests in test_output should be prepared.