### PR TITLE
Improve the error messages around colalign

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -1597,6 +1597,10 @@ def tabulate(
     aligns = [numalign if ct in [int, float] else stralign for ct in coltypes]
     if colalign is not None:
         assert isinstance(colalign, Iterable)
+
+        if not isinstance(colalign, (list, tuple)):
+            raise ValueError("colalign should be a list or tuple")
+
         for idx, align in enumerate(colalign):
             aligns[idx] = align
     minwidths = (

--- a/tabulate.py
+++ b/tabulate.py
@@ -1602,7 +1602,12 @@ def tabulate(
             raise ValueError("colalign should be a list or tuple")
 
         for idx, align in enumerate(colalign):
-            aligns[idx] = align
+            try:
+                aligns[idx] = align
+            except IndexError:
+                # This means the user has passed more values in ``colalign``
+                # then there are columns.  Drop the extra alignments.
+                pass
     minwidths = (
         [width_fn(h) + min_padding for h in headers] if headers else [0] * len(cols)
     )

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -480,3 +480,11 @@ def test_py27orlater_list_of_ordereddicts():
     expected = "\n".join(["  b    a", "---  ---", "  1    2", "  1    2"])
     result = tabulate(lod, headers="keys")
     assert_equal(expected, result)
+
+
+def test_colalign_with_bad_type_is_error():
+    "Input: colalign which is not a list or tuple"
+    table = []
+
+    with raises(ValueError, match="colalign should be a list or tuple"):
+        tabulate(table, colalign="right")

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -488,3 +488,21 @@ def test_colalign_with_bad_type_is_error():
 
     with raises(ValueError, match="colalign should be a list or tuple"):
         tabulate(table, colalign="right")
+
+
+def test_more_colalign_than_headers():
+    "Input: a list of headers and colalign with more colalign than headers (issue #84)"
+    table = [("square", 4), ("triangle", 3), ("circle", 1)]
+    headers = ["name", "sides"]
+    colalign = ["left", "right", "right"]
+
+    tabulate(table, headers=headers, colalign=colalign)
+
+
+def test_colalign_with_empty_input():
+    "Input: a list of headers and colalign with more colalign than headers (issue #84)"
+    table = []
+    headers = ["h1", "h2"]
+    colalign = ["left", "right"]
+
+    tabulate(table, headers=headers, colalign=colalign)

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1613,3 +1613,24 @@ def test_preserve_whitespace():
     expected = "\n".join(["h1    h2    h3", "----  ----  ----", "foo   bar   foo"])
     result = tabulate(test_table, table_headers)
     assert_equal(expected, result)
+
+
+def test_colalign_with_no_data():
+    "Output: a table with empty data, but with colalign specified (issue #89)"
+    table_headers = ["h1", "h2"]
+    colalign = ["left", "right"]
+    test_table = []
+    expected = "\n".join(["h1    h2", "----  ----"])
+    result = tabulate(test_table, headers=table_headers, colalign=colalign)
+    assert_equal(expected, result)
+
+
+def test_colalign_with_mixed_data():
+    "Output: a table with mixed data and a specified colalign (issue #89)"
+    table_headers = ["h1", "h2"]
+    test_table = [["", "abcdef"], [1, "abc"]]
+    expected = "\n".join(
+        ["h1        h2", "----  ------", "      abcdef", "1        abc"]
+    )
+    result = tabulate(test_table, headers=table_headers, colalign=("left", "right"))
+    assert_equal(expected, result)


### PR DESCRIPTION
Two changes:

* If the user passes more entries in `colalign` than there are columns, quietly drop the extra alignment parameters. Closes #84 and #89.

   My original suggestion was to have a better error message here, but the library can do something sensible here – drop those extra arguments. In particular, the example of the empty table in #89 made me think dropping this error was better than throwing an error.

* If the user passes a non tuple/list as the `colalign` argument, throw an error. This is the underlying issue in https://github.com/astanin/python-tabulate/issues/89#issuecomment-742673598, I think. It's definitely not going to do what the user expects, because the alignments are assigned character-by-character.

I added tests to cover these issues, plus a couple of other examples from the tickets that I wanted to check I hadn't broken.