### PR TITLE
Fix to issue#127 - Cell Text is Vertical Instead of Horizontal

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -1089,7 +1089,7 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
             # likely a conventional dict
             keys = tabular_data.keys()
             if (all(type(value) in (str,int) for value in tabular_data.values())):
-                rows = [tabular_data.values()]
+                rows = [tabular_data.values()] # make the dictionary a list 
             else:    
                 rows = list(
                     izip_longest(*tabular_data.values())

--- a/tabulate.py
+++ b/tabulate.py
@@ -1088,9 +1088,12 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
         if hasattr(tabular_data.values, "__call__"):
             # likely a conventional dict
             keys = tabular_data.keys()
-            rows = list(
-                izip_longest(*tabular_data.values())
-            )  # columns have to be transposed
+            if (all(type(value) in (str,int) for value in tabular_data.values())):
+                rows = [tabular_data.values()]
+            else:    
+                rows = list(
+                    izip_longest(*tabular_data.values())
+                )  # columns have to be transposed
         elif hasattr(tabular_data, "index"):
             # values is a property, has .index => it's likely a pandas.DataFrame (pandas 0.11.0)
             keys = list(tabular_data)

--- a/test/test_vertical.py
+++ b/test/test_vertical.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+"""Test output of the various forms of tabular data."""
+import tabulate as tabulate_module
+from tabulate import tabulate
+from common import assert_equal
+
+def test_vertical():
+    "Input: a dict of iterables with keys."
+    table = {"song_name_question": 'Toxic', "album_name_question": "Singles", "artist_name_question": "Britney Spears"}    
+   
+    expected = "\n".join(
+        ["song_name_question    album_name_question    artist_name_question", "Toxic                 Singles                Britney Spears"]
+    )
+    result = tabulate(table, headers='keys',tablefmt="plain") 
+    assert_equal(expected, result)   

--- a/test/test_vertical_to_horizontal.py
+++ b/test/test_vertical_to_horizontal.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 """Test output of the various forms of tabular data."""
-import tabulate as tabulate_module
 from tabulate import tabulate
 from common import assert_equal
 
@@ -12,5 +11,6 @@ def test_vertical_to_horizontal():
     expected = "\n".join(
         ["song_name_question    album_name_question    artist_name_question", "Toxic                 Singles                Britney Spears"]
     )
+
     result = tabulate(table, headers='keys',tablefmt="plain") 
     assert_equal(expected, result)   

--- a/test/test_vertical_to_horizontal.py
+++ b/test/test_vertical_to_horizontal.py
@@ -5,7 +5,7 @@ import tabulate as tabulate_module
 from tabulate import tabulate
 from common import assert_equal
 
-def test_vertical():
+def test_vertical_to_horizontal():
     "Input: a dict of iterables with keys."
     table = {"song_name_question": 'Toxic', "album_name_question": "Singles", "artist_name_question": "Britney Spears"}    
    


### PR DESCRIPTION
Fixed the problem in function `_normalize_tabular_data` where I make the dictionary a list if the dictionary values are string or integer, else transpose columns. Here is the change

```
if (all(type(value) in (str,int) for value in tabular_data.values())):
                rows = [tabular_data.values()] # make the dictionary a list 
else:    
                rows = list(
                    izip_longest(*tabular_data.values())
                )  # columns have to be transposed
```

I added tests `test_vertical_to_horizontal.py` to cover this issue. Here is the my pytest report

```

$ pytest
============================================================= test session starts =============================================================
platform win32 -- Python 3.8.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: C:\Indira\python-tabulate
collected 199 items

test\test_api.py ...                                                                                                                     [  1%] 
test\test_cli.py .......                                                                                                                 [  5%]
test\test_input.py .............................                                                                                         [ 19%]
test\test_internal.py ...........                                                                                                        [ 25%]
test\test_output.py ...........................................................................................................          [ 78%]
test\test_regression.py ................s..............                                                                                  [ 94%]
test\test_textwrapper.py ..........                                                                                                      [ 99%]
test\test_vertical_to_horizontal.py .                                                                                                    [100%] 

======================================================= 198 passed, 1 skipped in 1.83s ======================================================== 
```