### PR TITLE
fix afterpoint of numbers with thousand separators resulting in correct decimal alignment

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -572,6 +572,10 @@ _invisible_codes_link = re.compile(
 
 _ansi_color_reset_code = "\033[0m"
 
+_float_with_thousands_separators = re.compile(
+    r"^(([+-]?[0-9]{1,3})(?:,([0-9]{3}))*)?(?(1)\.[0-9]*|\.[0-9]+)?$"
+)
+
 
 def simple_separated_format(separator):
     """Construct a simple TableFormat with columns separated by a separator.
@@ -591,6 +595,42 @@ def simple_separated_format(separator):
         padding=0,
         with_header_hide=None,
     )
+
+
+def _isnumber_with_thousands_separator(string):
+    """
+    >>> _isnumber_with_thousands_separator(".")
+    False
+    >>> _isnumber_with_thousands_separator("1")
+    True
+    >>> _isnumber_with_thousands_separator("1.")
+    True
+    >>> _isnumber_with_thousands_separator(".1")
+    True
+    >>> _isnumber_with_thousands_separator("1000")
+    False
+    >>> _isnumber_with_thousands_separator("1,000")
+    True
+    >>> _isnumber_with_thousands_separator("1,0000")
+    False
+    >>> _isnumber_with_thousands_separator("1,000.1234")
+    True
+    >>> _isnumber_with_thousands_separator(b"1,000.1234")
+    True
+    >>> _isnumber_with_thousands_separator("+1,000.1234")
+    True
+    >>> _isnumber_with_thousands_separator("-1,000.1234")
+    True
+    """
+    try:
+        string = string.decode()
+    except (UnicodeDecodeError, AttributeError):
+        pass
+
+    if re.match(_float_with_thousands_separators, string):
+        return True
+
+    return False
 
 
 def _isconvertible(conv, string):
@@ -701,9 +741,11 @@ def _afterpoint(string):
     -1
     >>> _afterpoint("123e45")
     2
+    >>> _afterpoint("123,456.78")
+    2
 
     """
-    if _isnumber(string):
+    if _isnumber(string) or _isnumber_with_thousands_separator(string):
         if _isint(string):
             return -1
         else:

--- a/tabulate.py
+++ b/tabulate.py
@@ -627,10 +627,7 @@ def _isnumber_with_thousands_separator(string):
     except (UnicodeDecodeError, AttributeError):
         pass
 
-    if re.match(_float_with_thousands_separators, string):
-        return True
-
-    return False
+    return bool(re.match(_float_with_thousands_separators, string))
 
 
 def _isconvertible(conv, string):

--- a/test/test_internal.py
+++ b/test/test_internal.py
@@ -31,6 +31,36 @@ def test_align_column_decimal():
     assert_equal(output, expected)
 
 
+def test_align_column_decimal_with_thousand_separators():
+    "Internal: _align_column(..., 'decimal')"
+    column = ["12.345", "-1234.5", "1.23", "1,234.5", "1e+234", "1.0e234"]
+    output = T._align_column(column, "decimal")
+    expected = [
+        "   12.345  ",
+        "-1234.5    ",
+        "    1.23   ",
+        "1,234.5    ",
+        "    1e+234 ",
+        "    1.0e234",
+    ]
+    assert_equal(output, expected)
+
+
+def test_align_column_decimal_with_incorrect_thousand_separators():
+    "Internal: _align_column(..., 'decimal')"
+    column = ["12.345", "-1234.5", "1.23", "12,34.5", "1e+234", "1.0e234"]
+    output = T._align_column(column, "decimal")
+    expected = [
+        "     12.345  ",
+        "  -1234.5    ",
+        "      1.23   ",
+        "12,34.5      ",
+        "      1e+234 ",
+        "      1.0e234",
+    ]
+    assert_equal(output, expected)
+
+
 def test_align_column_none():
     "Internal: _align_column(..., None)"
     column = ["123.4", "56.7890"]


### PR DESCRIPTION
Fixes #130. It arrises as the function `_afterpoint` fails to recognize numbers with thousand separators. This happens because the function `_afterpoint` relies on the function `_isnumber` which relies on the built-in function `float.__init__` which fails on thousand-separated numbers. 

I did not change the function `_isnumber` as numbers such as "123,123" are to be aligned as plain text, resulting from the issue #110 and subsequent pulls and tests (`test/test_regression.py::test_string_with_comma_between_digits_without_floatfmt_grouping_option`). 

The solution is therefore implemented in the function `_afterpoint` by checking not only `_isnumber` but also a new function `__isnumber_with_thousands_separator` which validates floats or ints with thousand separators in [byte]string form. This is done by regex `r"^(([+-]?[0-9]{1,3})(?:,([0-9]{3}))*)?(?(1)\.[0-9]*|\.[0-9]+)?$"` which simply optionally matches signs, then the leading group, then separated thousands, and then the decimal part. A decimal part is required if the non-decimal part is empty. 

The tests were implemented only for the function `tabulate._align_column`.