### PR TITLE
provide a parameter that allows for controlling header maxcolwidth

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -1251,6 +1251,7 @@ def tabulate(
     disable_numparse=False,
     colalign=None,
     maxcolwidths=None,
+    maxheadercolwidths=None,
 ):
     """Format a fixed width table for pretty printing.
 
@@ -1572,6 +1573,7 @@ def tabulate(
     |            |            | better if it is wrapped a bit |
     +------------+------------+-------------------------------+
 
+    Header column width can be specified in a similar way using `maxheadercolwidth`
 
     """
 
@@ -1592,6 +1594,19 @@ def tabulate(
         list_of_lists = _wrap_text_to_colwidths(
             list_of_lists, maxcolwidths, numparses=numparses
         )
+
+    if maxheadercolwidths is not None:
+        num_cols = len(list_of_lists[0])
+        if isinstance(maxheadercolwidths, int):  # Expand scalar for all columns
+            maxheadercolwidths = _expand_iterable(maxheadercolwidths, num_cols, maxheadercolwidths)
+        else:  # Ignore col width for any 'trailing' columns
+            maxheadercolwidths = _expand_iterable(maxheadercolwidths, num_cols, None)
+
+        numparses = _expand_numparse(disable_numparse, num_cols)
+        headers = _wrap_text_to_colwidths(
+            [headers], maxheadercolwidths, numparses=numparses
+        )[0]
+
 
     # empty values in the first column of RST tables should be escaped (issue #82)
     # "" should be escaped as "\\ " or ".."

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -56,6 +56,7 @@ def test_tabulate_signature():
         ("disable_numparse", False),
         ("colalign", None),
         ("maxcolwidths", None),
+        ("maxheadercolwidths", None),
     ]
     _check_signature(tabulate, expected_sig)
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -200,6 +200,14 @@ def test_maxcolwidth_honor_disable_parsenum():
     result = tabulate(table, tablefmt="grid", maxcolwidths=6, disable_numparse=[2])
     assert_equal(expected, result)
 
+def test_plain_maxheadercolwidths_autowraps():
+    "Output: maxheadercolwidths will result in autowrapping header cell"
+    table = [["hdr", "fold"], ["1", "very long data"]]
+    expected = "\n".join(["  hdr  fo","       ld", "    1  very long", "       data"])
+    result = tabulate(
+        table, headers="firstrow", tablefmt="plain", maxcolwidths=[10, 10], maxheadercolwidths=[None, 2]
+    )
+    assert_equal(expected, result)
 
 def test_simple():
     "Output: simple with headers"


### PR DESCRIPTION
Used a separate parameter to not break any usage/thoughts for maxcolwidth in the data. I can see how it may be useful to keep the two separate