### PR TITLE
Drop support for EOL Python <= 3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: 19.3b0
+    rev: 21.12b0
     hooks:
     -   id: black
         args: [--safe]

--- a/README.md
+++ b/README.md
@@ -785,4 +785,4 @@ Wes Turner, Andrew Tija, Marco Gorelli, Sean McGinnis, danja100,
 endolith, Dominic Davis-Foster, pavlocat, Daniel Aslau, paulc,
 Felix Yan, Shane Loretz, Frank Busse, Harsh Singh, Derek Weitzel,
 Vladimir Vrzić, 서승우 (chrd5273), Georgy Frolov, Christian Cwienk,
-Bart Broere, Vilhelm Prytz.
+Bart Broere, Vilhelm Prytz, Hugo van Kemenade.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ environment:
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python39"
-    - PYTHON: "C:\\Python310"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"
     - PYTHON: "C:\\Python39-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+image: Visual Studio 2022
 environment:
 
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,16 +7,14 @@ environment:
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
 
-    - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
-    - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python35-x64"
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python39"
+    - PYTHON: "C:\\Python310"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python39-x64"
+    - PYTHON: "C:\\Python310-x64"
 
 install:
   # We need wheel installed to build wheels

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from __future__ import print_function
 from timeit import timeit
 import tabulate
 import asciitable

--- a/benchmark.py
+++ b/benchmark.py
@@ -7,27 +7,14 @@ import asciitable
 import prettytable
 import texttable
 import sys
-import codecs
-from platform import python_version_tuple
 
 setup_code = r"""
 from csv import writer
-try: # Python 2
-    from StringIO import StringIO
-except: # Python 3
-    from io import StringIO
+from io import StringIO
 import tabulate
 import asciitable
 import prettytable
 import texttable
-
-
-import platform
-if platform.platform().startswith("Windows") \
-   and \
-   platform.python_version_tuple() < ('3','6','0'):
-    import win_unicode_console
-    win_unicode_console.enable()
 
 
 table=[["some text"]+list(range(i,i+9)) for i in range(10)]
@@ -108,14 +95,7 @@ def benchmark(n):
         results, ["Table formatter", "time, μs", "rel. time"], "rst", floatfmt=".1f"
     )
 
-    from platform import platform
-
-    if platform().startswith("Windows"):
-        print(table)
-    elif python_version_tuple()[0] < "3":
-        print(codecs.encode(table, "utf-8"))
-    else:
-        print(table)
+    print(table)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -6,21 +6,17 @@ except ImportError:
     from distutils.core import setup
 
 
-from platform import python_version_tuple, python_implementation
+from platform import python_implementation
 import os
 import re
 
-# strip links from the descripton on the PyPI
-if python_version_tuple()[0] >= "3":
-    LONG_DESCRIPTION = open("README.md", "r", encoding="utf-8").read()
-else:
-    LONG_DESCRIPTION = open("README.md", "r").read()
+# strip links from the description on the PyPI
+LONG_DESCRIPTION = open("README.md", "r", encoding="utf-8").read()
 
 # strip Build Status from the PyPI package
 try:
-    if python_version_tuple()[:2] >= ("2", "7"):
-        status_re = "^Build status\n(.*\n){7}"
-        LONG_DESCRIPTION = re.sub(status_re, "", LONG_DESCRIPTION, flags=re.M)
+    status_re = "^Build status\n(.*\n){7}"
+    LONG_DESCRIPTION = re.sub(status_re, "", LONG_DESCRIPTION, flags=re.M)
 except TypeError:
     if python_implementation() == "IronPython":
         # IronPython doesn't support flags in re.sub (IronPython issue #923)
@@ -46,20 +42,17 @@ setup(
     author_email="s.astanin@gmail.com",
     url="https://github.com/astanin/python-tabulate",
     license="MIT",
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries",
     ],
     py_modules=["tabulate"],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 import re
 
 # strip links from the description on the PyPI
-LONG_DESCRIPTION = open("README.md", "r", encoding="utf-8").read()
+LONG_DESCRIPTION = open("README.md", encoding="utf-8").read()
 
 # strip Build Status from the PyPI package
 try:
@@ -25,7 +25,7 @@ except TypeError:
         raise
 
 install_options = os.environ.get("TABULATE_INSTALL", "").split(",")
-libonly_flags = set(["lib-only", "libonly", "no-cli", "without-cli"])
+libonly_flags = {"lib-only", "libonly", "no-cli", "without-cli"}
 if libonly_flags.intersection(install_options):
     console_scripts = []
 else:

--- a/tabulate.py
+++ b/tabulate.py
@@ -594,7 +594,7 @@ def _isint(string, inttype=int):
     """
     return (
         type(string) is inttype
-        or (isinstance(string, bytes) or isinstance(string, str))
+        or isinstance(string, (bytes, str))
         and _isconvertible(inttype, string)
     )
 
@@ -629,7 +629,7 @@ def _type(string, has_invisible=True, numparse=True):
 
     """
 
-    if has_invisible and (isinstance(string, str) or isinstance(string, bytes)):
+    if has_invisible and isinstance(string, (str, bytes)):
         string = _strip_invisible(string)
 
     if string is None:
@@ -738,7 +738,7 @@ def _visible_width(s):
         len_fn = wcwidth.wcswidth
     else:
         len_fn = len
-    if isinstance(s, str) or isinstance(s, bytes):
+    if isinstance(s, (str, bytes)):
         return len_fn(_strip_invisible(s))
     else:
         return len_fn(str(s))

--- a/tabulate.py
+++ b/tabulate.py
@@ -1,9 +1,5 @@
-# -*- coding: utf-8 -*-
-
 """Pretty-print tabular data."""
 
-from __future__ import print_function
-from __future__ import unicode_literals
 from collections import namedtuple
 from collections.abc import Iterable
 from html import escape as htmlescape
@@ -167,7 +163,7 @@ def _html_row_with_attrs(celltag, unsafe, cell_values, colwidths, colaligns):
         ]
     rowhtml = "<tr>{}</tr>".format("".join(values_with_attrs).rstrip())
     if celltag == "th":  # it's a header row, create a new table header
-        rowhtml = "<table>\n<thead>\n{}\n</thead>\n<tbody>".format(rowhtml)
+        rowhtml = f"<table>\n<thead>\n{rowhtml}\n</thead>\n<tbody>"
     return rowhtml
 
 
@@ -179,7 +175,7 @@ def _moin_row_with_attrs(celltag, cell_values, colwidths, colaligns, header=""):
         "decimal": '<style="text-align: right;">',
     }
     values_with_attrs = [
-        "{0}{1} {2} ".format(celltag, alignment.get(a, ""), header + c + header)
+        "{}{} {} ".format(celltag, alignment.get(a, ""), header + c + header)
         for c, a in zip(cell_values, colaligns)
     ]
     return "".join(values_with_attrs) + "||"
@@ -939,7 +935,7 @@ def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
         return missingval
 
     if valtype in [int, str]:
-        return "{0}".format(val)
+        return f"{val}"
     elif valtype is bytes:
         try:
             return str(val, "ascii")
@@ -954,7 +950,7 @@ def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
         else:
             return format(float(val), floatfmt)
     else:
-        return "{0}".format(val)
+        return f"{val}"
 
 
 def _align_header(
@@ -975,7 +971,7 @@ def _align_header(
     elif alignment == "center":
         return _padboth(width, header)
     elif not alignment:
-        return "{0}".format(header)
+        return f"{header}"
     else:
         return _padleft(width, header)
 

--- a/tabulate.py
+++ b/tabulate.py
@@ -5,61 +5,23 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 from collections import namedtuple
-import sys
+from collections.abc import Iterable
+from html import escape as htmlescape
+from itertools import zip_longest as izip_longest
+from functools import reduce, partial
+import io
 import re
 import math
 import textwrap
-
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Iterable
-else:
-    from collections import Iterable
-
-if sys.version_info[0] < 3:
-    from itertools import izip_longest
-    from functools import partial
-
-    _none_type = type(None)
-    _bool_type = bool
-    _int_type = int
-    _long_type = long  # noqa
-    _float_type = float
-    _text_type = unicode  # noqa
-    _binary_type = str
-
-    def _is_file(f):
-        return hasattr(f, "read")
-
-
-else:
-    from itertools import zip_longest as izip_longest
-    from functools import reduce, partial
-
-    _none_type = type(None)
-    _bool_type = bool
-    _int_type = int
-    _long_type = int
-    _float_type = float
-    _text_type = str
-    _binary_type = bytes
-    basestring = str
-
-    import io
-
-    def _is_file(f):
-        return isinstance(f, io.IOBase)
-
 
 try:
     import wcwidth  # optional wide-character (CJK) support
 except ImportError:
     wcwidth = None
 
-try:
-    from html import escape as htmlescape
-except ImportError:
-    from cgi import escape as htmlescape
+
+def _is_file(f):
+    return isinstance(f, io.IOBase)
 
 
 __all__ = ["tabulate", "tabulate_formats", "simple_separated_format"]
@@ -89,7 +51,7 @@ Line = namedtuple("Line", ["begin", "hline", "sep", "end"])
 DataRow = namedtuple("DataRow", ["begin", "sep", "end"])
 
 
-# A table structure is suppposed to be:
+# A table structure is supposed to be:
 #
 #     --- lineabove ---------
 #         headerrow
@@ -263,7 +225,7 @@ def _latex_row(cell_values, colwidths, colaligns, escrules=LATEX_ESCAPE_RULES):
 
 def _rst_escape_first_column(rows, headers):
     def escape_empty(val):
-        if isinstance(val, (_text_type, _binary_type)) and not val.strip():
+        if isinstance(val, (str, bytes)) and not val.strip():
             return ".."
         else:
             return val
@@ -616,7 +578,7 @@ def _isnumber(string):
     """
     if not _isconvertible(float, string):
         return False
-    elif isinstance(string, (_text_type, _binary_type)) and (
+    elif isinstance(string, (str, bytes)) and (
         math.isinf(float(string)) or math.isnan(float(string))
     ):
         return string.lower() in ["inf", "-inf", "nan"]
@@ -632,7 +594,7 @@ def _isint(string, inttype=int):
     """
     return (
         type(string) is inttype
-        or (isinstance(string, _binary_type) or isinstance(string, _text_type))
+        or (isinstance(string, bytes) or isinstance(string, str))
         and _isconvertible(inttype, string)
     )
 
@@ -646,8 +608,8 @@ def _isbool(string):
     >>> _isbool(1)
     False
     """
-    return type(string) is _bool_type or (
-        isinstance(string, (_binary_type, _text_type)) and string in ("True", "False")
+    return type(string) is bool or (
+        isinstance(string, (bytes, str)) and string in ("True", "False")
     )
 
 
@@ -667,27 +629,23 @@ def _type(string, has_invisible=True, numparse=True):
 
     """
 
-    if has_invisible and (
-        isinstance(string, _text_type) or isinstance(string, _binary_type)
-    ):
+    if has_invisible and (isinstance(string, str) or isinstance(string, bytes)):
         string = _strip_invisible(string)
 
     if string is None:
-        return _none_type
+        return type(None)
     elif hasattr(string, "isoformat"):  # datetime.datetime, date, and time
-        return _text_type
+        return str
     elif _isbool(string):
-        return _bool_type
+        return bool
     elif _isint(string) and numparse:
-        return int
-    elif _isint(string, _long_type) and numparse:
         return int
     elif _isnumber(string) and numparse:
         return float
-    elif isinstance(string, _binary_type):
-        return _binary_type
+    elif isinstance(string, bytes):
+        return bytes
     else:
-        return _text_type
+        return str
 
 
 def _afterpoint(string):
@@ -761,7 +719,7 @@ def _strip_invisible(s):
     'This is a link'
 
     """
-    if isinstance(s, _text_type):
+    if isinstance(s, str):
         links_removed = re.sub(_invisible_codes_link, "\\1", s)
         return re.sub(_invisible_codes, "", links_removed)
     else:  # a bytestring
@@ -780,14 +738,14 @@ def _visible_width(s):
         len_fn = wcwidth.wcswidth
     else:
         len_fn = len
-    if isinstance(s, _text_type) or isinstance(s, _binary_type):
+    if isinstance(s, str) or isinstance(s, bytes):
         return len_fn(_strip_invisible(s))
     else:
-        return len_fn(_text_type(s))
+        return len_fn(str(s))
 
 
 def _is_multiline(s):
-    if isinstance(s, _text_type):
+    if isinstance(s, str):
         return bool(re.search(_multiline_codes, s))
     else:  # a bytestring
         return bool(re.search(_multiline_codes_bytes, s))
@@ -920,20 +878,20 @@ def _align_column(
 
 def _more_generic(type1, type2):
     types = {
-        _none_type: 0,
-        _bool_type: 1,
+        type(None): 0,
+        bool: 1,
         int: 2,
         float: 3,
-        _binary_type: 4,
-        _text_type: 5,
+        bytes: 4,
+        str: 5,
     }
     invtypes = {
-        5: _text_type,
-        4: _binary_type,
+        5: str,
+        4: bytes,
         3: float,
         2: int,
-        1: _bool_type,
-        0: _none_type,
+        1: bool,
+        0: type(None),
     }
     moregeneric = max(types.get(type1, 5), types.get(type2, 5))
     return invtypes[moregeneric]
@@ -942,27 +900,27 @@ def _more_generic(type1, type2):
 def _column_type(strings, has_invisible=True, numparse=True):
     """The least generic type all column values are convertible to.
 
-    >>> _column_type([True, False]) is _bool_type
+    >>> _column_type([True, False]) is bool
     True
-    >>> _column_type(["1", "2"]) is _int_type
+    >>> _column_type(["1", "2"]) is int
     True
-    >>> _column_type(["1", "2.3"]) is _float_type
+    >>> _column_type(["1", "2.3"]) is float
     True
-    >>> _column_type(["1", "2.3", "four"]) is _text_type
+    >>> _column_type(["1", "2.3", "four"]) is str
     True
-    >>> _column_type(["four", '\u043f\u044f\u0442\u044c']) is _text_type
+    >>> _column_type(["four", '\u043f\u044f\u0442\u044c']) is str
     True
-    >>> _column_type([None, "brux"]) is _text_type
+    >>> _column_type([None, "brux"]) is str
     True
-    >>> _column_type([1, 2, None]) is _int_type
+    >>> _column_type([1, 2, None]) is int
     True
     >>> import datetime as dt
-    >>> _column_type([dt.datetime(1991,2,19), dt.time(17,35)]) is _text_type
+    >>> _column_type([dt.datetime(1991,2,19), dt.time(17,35)]) is str
     True
 
     """
     types = [_type(s, has_invisible, numparse) for s in strings]
-    return reduce(_more_generic, types, _bool_type)
+    return reduce(_more_generic, types, bool)
 
 
 def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
@@ -980,17 +938,15 @@ def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
     if val is None:
         return missingval
 
-    if valtype in [int, _text_type]:
+    if valtype in [int, str]:
         return "{0}".format(val)
-    elif valtype is _binary_type:
+    elif valtype is bytes:
         try:
-            return _text_type(val, "ascii")
+            return str(val, "ascii")
         except TypeError:
-            return _text_type(val)
+            return str(val)
     elif valtype is float:
-        is_a_colored_number = has_invisible and isinstance(
-            val, (_text_type, _binary_type)
-        )
+        is_a_colored_number = has_invisible and isinstance(val, (str, bytes))
         if is_a_colored_number:
             raw_val = _strip_invisible(val)
             formatted_val = format(float(raw_val), floatfmt)
@@ -1110,7 +1066,7 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
             raise ValueError("tabular data doesn't appear to be a dict or a DataFrame")
 
         if headers == "keys":
-            headers = list(map(_text_type, keys))  # headers should be strings
+            headers = list(map(str, keys))  # headers should be strings
 
     else:  # it's a usual an iterable of iterables, or a NumPy array
         rows = list(tabular_data)
@@ -1132,7 +1088,7 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
             and hasattr(rows[0], "_fields")
         ):
             # namedtuple
-            headers = list(map(_text_type, rows[0]._fields))
+            headers = list(map(str, rows[0]._fields))
         elif len(rows) > 0 and hasattr(rows[0], "keys") and hasattr(rows[0], "values"):
             # dict-like object
             uniq_keys = set()  # implements hashed lookup
@@ -1153,11 +1109,11 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
             elif isinstance(headers, dict):
                 # a dict of headers for a list of dicts
                 headers = [headers.get(k, k) for k in keys]
-                headers = list(map(_text_type, headers))
+                headers = list(map(str, headers))
             elif headers == "firstrow":
                 if len(rows) > 0:
                     headers = [firstdict.get(k, k) for k in keys]
-                    headers = list(map(_text_type, headers))
+                    headers = list(map(str, headers))
                 else:
                     headers = []
             elif headers:
@@ -1178,7 +1134,7 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
 
         elif headers == "keys" and len(rows) > 0:
             # keys are column indices
-            headers = list(map(_text_type, range(len(rows[0]))))
+            headers = list(map(str, range(len(rows[0]))))
 
     # take headers from the first row if necessary
     if headers == "firstrow" and len(rows) > 0:
@@ -1187,14 +1143,14 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
             index = index[1:]
         else:
             headers = rows[0]
-        headers = list(map(_text_type, headers))  # headers should be strings
+        headers = list(map(str, headers))  # headers should be strings
         rows = rows[1:]
 
-    headers = list(map(_text_type, headers))
+    headers = list(map(str, headers))
     rows = list(map(list, rows))
 
     # add or remove an index column
-    showindex_is_a_str = type(showindex) in [_text_type, _binary_type]
+    showindex_is_a_str = type(showindex) in [str, bytes]
     if showindex == "default" and index is not None:
         rows = _prepend_row_index(rows, index)
     elif isinstance(showindex, Iterable) and not showindex_is_a_str:
@@ -1615,8 +1571,8 @@ def tabulate(
     # optimization: look for ANSI control codes once,
     # enable smart width functions only if a control code is found
     plain_text = "\t".join(
-        ["\t".join(map(_text_type, headers))]
-        + ["\t".join(map(_text_type, row)) for row in list_of_lists]
+        ["\t".join(map(str, headers))]
+        + ["\t".join(map(str, row)) for row in list_of_lists]
     )
 
     has_invisible = re.search(_invisible_codes, plain_text)
@@ -1638,7 +1594,7 @@ def tabulate(
     cols = list(izip_longest(*list_of_lists))
     numparses = _expand_numparse(disable_numparse, len(cols))
     coltypes = [_column_type(col, numparse=np) for col, np in zip(cols, numparses)]
-    if isinstance(floatfmt, basestring):  # old version
+    if isinstance(floatfmt, str):  # old version
         float_formats = len(cols) * [
             floatfmt
         ]  # just duplicate the string to use in each column
@@ -1646,7 +1602,7 @@ def tabulate(
         float_formats = list(floatfmt)
         if len(float_formats) < len(cols):
             float_formats.extend((len(cols) - len(float_formats)) * [_DEFAULT_FLOATFMT])
-    if isinstance(missingval, basestring):
+    if isinstance(missingval, str):
         missing_vals = len(cols) * [missingval]
     else:
         missing_vals = list(missingval)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -2,8 +2,6 @@
 
 """
 
-from __future__ import print_function
-from __future__ import unicode_literals
 from tabulate import tabulate, tabulate_formats, simple_separated_format
 from common import skip
 
@@ -21,14 +19,14 @@ def test_tabulate_formats():
     print("tabulate_formats = %r" % supported)
     assert type(supported) is list
     for fmt in supported:
-        assert type(fmt) is type("")  # noqa
+        assert type(fmt) is str  # noqa
 
 
 def _check_signature(function, expected_sig):
     if not signature:
         skip("")
     actual_sig = signature(function)
-    print("expected: %s\nactual: %s\n" % (expected_sig, str(actual_sig)))
+    print(f"expected: {expected_sig}\nactual: {str(actual_sig)}\n")
 
     assert len(actual_sig.parameters) == len(expected_sig)
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -5,16 +5,11 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 from tabulate import tabulate, tabulate_formats, simple_separated_format
-from platform import python_version_tuple
 from common import skip
 
 
 try:
-    if python_version_tuple() >= ("3", "3", "0"):
-        from inspect import signature, _empty
-    else:
-        signature = None
-        _empty = None
+    from inspect import signature, _empty
 except ImportError:
     signature = None
     _empty = None

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,8 +3,6 @@
 """
 
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import os
 import sys
 
@@ -93,11 +91,11 @@ def run_and_capture_stdout(cmd, input=None):
     out, err = x.communicate(input=input_buf)
     out = out.decode("utf-8")
     if x.returncode != 0:
-        raise IOError(err)
+        raise OSError(err)
     return out
 
 
-class TemporaryTextFile(object):
+class TemporaryTextFile:
     def __init__(self):
         self.tmpfile = None
 

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -471,7 +471,7 @@ def test_list_of_dicts_with_list_of_headers():
         tabulate(table, headers=headers)
 
 
-def test_py27orlater_list_of_ordereddicts():
+def test_list_of_ordereddicts():
     "Input: a list of OrderedDicts."
     from collections import OrderedDict
 

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -1,9 +1,5 @@
-# -*- coding: utf-8 -*-
-
 """Test support of the various forms of tabular data."""
 
-from __future__ import print_function
-from __future__ import unicode_literals
 from tabulate import tabulate
 from common import assert_equal, assert_in, raises, skip
 

--- a/test/test_internal.py
+++ b/test/test_internal.py
@@ -1,9 +1,5 @@
-# -*- coding: utf-8 -*-
-
 """Tests of the internal tabulate functions."""
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import tabulate as T
 from common import assert_equal, skip
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1,9 +1,5 @@
-# -*- coding: utf-8 -*-
-
 """Test output of the various forms of tabular data."""
 
-from __future__ import print_function
-from __future__ import unicode_literals
 import tabulate as tabulate_module
 from tabulate import tabulate, simple_separated_format
 from common import assert_equal, raises, skip

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,9 +1,5 @@
-# -*- coding: utf-8 -*-
-
 """Regression tests."""
 
-from __future__ import print_function
-from __future__ import unicode_literals
 from tabulate import tabulate, TableFormat, Line, DataRow
 from common import assert_equal, skip
 
@@ -20,7 +16,7 @@ def test_ansi_color_in_table_cells():
             "| test   | \x1b[31mtest\x1b[0m   | \x1b[32mtest\x1b[0m   |",
         ]
     )
-    print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
+    print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")
     assert_equal(expected, formatted)
 
 
@@ -43,7 +39,7 @@ def test_alignment_of_colored_cells():
             "+--------+--------+--------+",
         ]
     )
-    print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
+    print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")
     assert_equal(expected, formatted)
 
 
@@ -66,7 +62,7 @@ def test_alignment_of_link_cells():
             "+--------+--------+--------+",
         ]
     )
-    print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
+    print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")
     assert_equal(expected, formatted)
 
 
@@ -89,7 +85,7 @@ def test_alignment_of_link_text_cells():
             "+--------+----------+--------+",
         ]
     )
-    print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
+    print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")
     assert_equal(expected, formatted)
 
 
@@ -98,15 +94,13 @@ def test_iter_of_iters_with_headers():
 
     def mk_iter_of_iters():
         def mk_iter():
-            for i in range(3):
-                yield i
+            yield from range(3)
 
         for r in range(3):
             yield mk_iter()
 
     def mk_headers():
-        for h in ["a", "b", "c"]:
-            yield h
+        yield from ["a", "b", "c"]
 
     formatted = tabulate(mk_iter_of_iters(), headers=mk_headers())
     expected = "\n".join(
@@ -118,7 +112,7 @@ def test_iter_of_iters_with_headers():
             "  0    1    2",
         ]
     )
-    print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
+    print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")
     assert_equal(expected, formatted)
 
 
@@ -137,7 +131,7 @@ def test_datetime_values():
             "-------------------  ----------  --------",
         ]
     )
-    print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
+    print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")
     assert_equal(expected, formatted)
 
 
@@ -148,7 +142,7 @@ def test_simple_separated_format():
     fmt = simple_separated_format("!")
     expected = "spam!eggs"
     formatted = tabulate([["spam", "eggs"]], tablefmt=fmt)
-    print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
+    print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")
     assert_equal(expected, formatted)
 
 
@@ -178,7 +172,7 @@ def test_numeric_column_headers():
     expected = "  42\n----\n   1\n   2"
     assert_equal(result, expected)
 
-    lod = [dict((p, i) for p in range(5)) for i in range(5)]
+    lod = [{p: i for p in range(5)} for i in range(5)]
     result = tabulate(lod, "keys")
     expected = "\n".join(
         [
@@ -206,7 +200,7 @@ def test_88_256_ANSI_color_codes():
             "| \x1b[48;5;196mred\x1b[49m          | \x1b[38;5;196mred\x1b[39m          |",
         ]
     )
-    print("expected: %r\n\ngot:      %r\n" % (expected, formatted))
+    print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")
     assert_equal(expected, formatted)
 
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -4,8 +4,8 @@
 
 from __future__ import print_function
 from __future__ import unicode_literals
-from tabulate import tabulate, _text_type, _long_type, TableFormat, Line, DataRow
-from common import assert_equal, assert_in, skip
+from tabulate import tabulate, TableFormat, Line, DataRow
+from common import assert_equal, skip
 
 
 def test_ansi_color_in_table_cells():
@@ -152,15 +152,6 @@ def test_simple_separated_format():
     assert_equal(expected, formatted)
 
 
-def py3test_require_py3():
-    "Regression: py33 tests should actually use Python 3 (issue #13)"
-    from platform import python_version_tuple
-
-    print("Expected Python version: 3.x.x")
-    print("Python version used for tests: %s.%s.%s" % python_version_tuple())
-    assert_equal(python_version_tuple()[0], "3")
-
-
 def test_simple_separated_format_with_headers():
     "Regression: simple_separated_format() on tables with headers (issue #15)"
     from tabulate import simple_separated_format
@@ -174,10 +165,10 @@ def test_simple_separated_format_with_headers():
 
 def test_column_type_of_bytestring_columns():
     "Regression: column type for columns of bytestrings (issue #16)"
-    from tabulate import _column_type, _binary_type
+    from tabulate import _column_type
 
     result = _column_type([b"foo", b"bar"])
-    expected = _binary_type
+    expected = bytes
     assert_equal(result, expected)
 
 
@@ -246,10 +237,9 @@ def test_latex_escape_special_chars():
 
 def test_isconvertible_on_set_values():
     "Regression: don't fail with TypeError on set values (issue #35)"
-    expected_py2 = "\n".join(["a    b", "---  -------", "Foo  set([])"])
-    expected_py3 = "\n".join(["a    b", "---  -----", "Foo  set()"])
+    expected = "\n".join(["a    b", "---  -----", "Foo  set()"])
     result = tabulate([["Foo", set()]], headers=["a", "b"])
-    assert_in(result, [expected_py2, expected_py3])
+    assert_equal(result, expected)
 
 
 def test_ansi_color_for_decimal_numbers():
@@ -304,7 +294,7 @@ def test_colorclass_colors():
         assert_equal(result, expected)
     except ImportError:
 
-        class textclass(_text_type):
+        class textclass(str):
             pass
 
         s = textclass("\x1b[35m3.14\x1b[39m")
@@ -357,7 +347,7 @@ def test_multiline_with_wide_characters():
 
 def test_align_long_integers():
     "Regression: long integers should be aligned as integers (issue #61)"
-    table = [[_long_type(1)], [_long_type(234)]]
+    table = [[int(1)], [int(234)]]
     result = tabulate(table, tablefmt="plain")
     expected = "\n".join(["  1", "234"])
     assert_equal(result, expected)

--- a/test/test_textwrapper.py
+++ b/test/test_textwrapper.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
 """Discretely test functionality of our custom TextWrapper"""
-from __future__ import unicode_literals
 
 from tabulate import _CustomTextWrap as CTW
 from textwrap import TextWrapper as OTW

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,10 @@
 # for testing and it is disabled by default.
 
 [tox]
-envlist = lint, py27, py35, py36, py37, py38, py39, py310
+envlist = lint, py{37, 38, 39, 310}
 
 [testenv]
-commands = pytest -v --doctest-modules --ignore benchmark.py
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =
     pytest
 passenv =
@@ -24,58 +24,15 @@ commands = python -m pre_commit run -a
 deps =
     pre-commit
 
-[testenv:py27-extra]
-basepython = python2.7
-commands = pytest -v --doctest-modules --ignore benchmark.py
-deps =
-    pytest
-    numpy
-    pandas
-    wcwidth
-
-
-[testenv:py35]
-basepython = python3.5
-commands = pytest -v --doctest-modules --ignore benchmark.py
-deps =
-    pytest
-
-
-[testenv:py35-extra]
-basepython = python3.5
-commands = pytest -v --doctest-modules --ignore benchmark.py
-deps =
-    pytest
-    numpy
-    pandas
-    wcwidth
-
-
-[testenv:py36]
-basepython = python3.6
-commands = pytest -v --doctest-modules --ignore benchmark.py
-deps =
-    pytest
-
-
-[testenv:py36-extra]
-basepython = python3.6
-commands = pytest -v --doctest-modules --ignore benchmark.py
-deps =
-    pytest
-    numpy
-    pandas
-    wcwidth
-
 [testenv:py37]
 basepython = python3.7
-commands = pytest -v --doctest-modules --ignore benchmark.py
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =
     pytest
 
 [testenv:py37-extra]
 basepython = python3.7
-commands = pytest -v --doctest-modules --ignore benchmark.py
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =
     pytest
     numpy
@@ -84,13 +41,13 @@ deps =
 
 [testenv:py38]
 basepython = python3.8
-commands = pytest -v --doctest-modules --ignore benchmark.py
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =
     pytest
 
 [testenv:py38-extra]
 basepython = python3.8
-commands = pytest -v --doctest-modules --ignore benchmark.py
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =
     pytest
     numpy
@@ -100,13 +57,13 @@ deps =
 
 [testenv:py39]
 basepython = python3.9
-commands = pytest -v --doctest-modules --ignore benchmark.py
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =
     pytest
 
 [testenv:py39-extra]
 basepython = python3.9
-commands = pytest -v --doctest-modules --ignore benchmark.py
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =
     pytest
     numpy
@@ -116,14 +73,14 @@ deps =
 
 [testenv:py310]
 basepython = python3.10
-commands = pytest -v --doctest-modules --ignore benchmark.py
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =
     pytest
 
 [testenv:py310-extra]
 basepython = python3.10
 setenv = PYTHONDEVMODE = 1
-commands = pytest -v --doctest-modules --ignore benchmark.py
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =
     pytest
     numpy


### PR DESCRIPTION
Python 2.7, 3.5 and 3.6 are EOL and no longer receiving security updates (or any updates) from the core Python team.

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.1 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |
| 3.5   | 3.5.10 | 2015-09-30 | 2020-09-13 |
| 2.7   | 2.7.18 | 2010-07-03 | 2020-01-01 |

https://endoflife.date/python

We can drop support for them, allowing us to use modern Python syntax, remove redundant compatibility code, reduce resource usage on the CI and make testing quicker.
