### PR TITLE
Add Markdown formatting for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,20 @@ Installation
 
 To install the Python library and the command line utility, run:
 
-    pip install tabulate
+```shell
+pip install tabulate
+```
 
 The command line utility will be installed as `tabulate` to `bin` on
 Linux (e.g. `/usr/bin`); or as `tabulate.exe` to `Scripts` in your
 Python installation on Windows (e.g.
-`C:\Python27\Scripts\tabulate.exe`).
+`C:\Python39\Scripts\tabulate.exe`).
 
 You may consider installing the library only for the current user:
 
-    pip install tabulate --user
+```shell
+pip install tabulate --user
+```
 
 In this case the command line utility will be installed to
 `~/.local/bin/tabulate` on Linux and to
@@ -36,12 +40,16 @@ In this case the command line utility will be installed to
 
 To install just the library on Unix-like operating systems:
 
-    TABULATE_INSTALL=lib-only pip install tabulate
+```shell
+TABULATE_INSTALL=lib-only pip install tabulate
+```
 
 On Windows:
 
-    set TABULATE_INSTALL=lib-only
-    pip install tabulate
+```shell
+set TABULATE_INSTALL=lib-only
+pip install tabulate
+```
 
 Build status
 ------------
@@ -55,17 +63,19 @@ The module provides just one function, `tabulate`, which takes a list of
 lists or another tabular data type as the first argument, and outputs a
 nicely formatted plain-text table:
 
-    >>> from tabulate import tabulate
+```pycon
+>>> from tabulate import tabulate
 
-    >>> table = [["Sun",696000,1989100000],["Earth",6371,5973.6],
-    ...          ["Moon",1737,73.5],["Mars",3390,641.85]]
-    >>> print(tabulate(table))
-    -----  ------  -------------
-    Sun    696000     1.9891e+09
-    Earth    6371  5973.6
-    Moon     1737    73.5
-    Mars     3390   641.85
-    -----  ------  -------------
+>>> table = [["Sun",696000,1989100000],["Earth",6371,5973.6],
+...          ["Moon",1737,73.5],["Mars",3390,641.85]]
+>>> print(tabulate(table))
+-----  ------  -------------
+Sun    696000     1.9891e+09
+Earth    6371  5973.6
+Moon     1737    73.5
+Mars     3390   641.85
+-----  ------  -------------
+```
 
 The following tabular data types are supported:
 
@@ -83,33 +93,39 @@ Examples in this file use Python2. Tabulate supports Python3 too.
 The second optional argument named `headers` defines a list of column
 headers to be used:
 
-    >>> print(tabulate(table, headers=["Planet","R (km)", "mass (x 10^29 kg)"]))
-    Planet      R (km)    mass (x 10^29 kg)
-    --------  --------  -------------------
-    Sun         696000           1.9891e+09
-    Earth         6371        5973.6
-    Moon          1737          73.5
-    Mars          3390         641.85
+```pycon
+>>> print(tabulate(table, headers=["Planet","R (km)", "mass (x 10^29 kg)"]))
+Planet      R (km)    mass (x 10^29 kg)
+--------  --------  -------------------
+Sun         696000           1.9891e+09
+Earth         6371        5973.6
+Moon          1737          73.5
+Mars          3390         641.85
+```
 
 If `headers="firstrow"`, then the first row of data is used:
 
-    >>> print(tabulate([["Name","Age"],["Alice",24],["Bob",19]],
-    ...                headers="firstrow"))
-    Name      Age
-    ------  -----
-    Alice      24
-    Bob        19
+```pycon
+>>> print(tabulate([["Name","Age"],["Alice",24],["Bob",19]],
+...                headers="firstrow"))
+Name      Age
+------  -----
+Alice      24
+Bob        19
+```
 
 If `headers="keys"`, then the keys of a dictionary/dataframe, or column
 indices are used. It also works for NumPy record arrays and lists of
 dictionaries or named tuples:
 
-    >>> print(tabulate({"Name": ["Alice", "Bob"],
-    ...                 "Age": [24, 19]}, headers="keys"))
-      Age  Name
-    -----  ------
-       24  Alice
-       19  Bob
+```pycon
+>>> print(tabulate({"Name": ["Alice", "Bob"],
+...                 "Age": [24, 19]}, headers="keys"))
+  Age  Name
+-----  ------
+   24  Alice
+   19  Bob
+```
 
 ### Row Indices
 
@@ -120,11 +136,13 @@ To suppress row indices for all types of data, pass `showindex="never"`
 or `showindex=False`. To add a custom row index column, pass
 `showindex=rowIDs`, where `rowIDs` is some iterable:
 
-    >>> print(tabulate([["F",24],["M",19]], showindex="always"))
-    -  -  --
-    0  F  24
-    1  M  19
-    -  -  --
+```pycon
+>>> print(tabulate([["F",24],["M",19]], showindex="always"))
+-  -  --
+0  F  24
+1  M  19
+-  -  --
+```
 
 ### Table format
 
@@ -159,211 +177,247 @@ Supported table formats are:
 
 `plain` tables do not use any pseudo-graphics to draw lines:
 
-    >>> table = [["spam",42],["eggs",451],["bacon",0]]
-    >>> headers = ["item", "qty"]
-    >>> print(tabulate(table, headers, tablefmt="plain"))
-    item      qty
-    spam       42
-    eggs      451
-    bacon       0
+```pycon
+>>> table = [["spam",42],["eggs",451],["bacon",0]]
+>>> headers = ["item", "qty"]
+>>> print(tabulate(table, headers, tablefmt="plain"))
+item      qty
+spam       42
+eggs      451
+bacon       0
+```
 
 `simple` is the default format (the default may change in future
 versions). It corresponds to `simple_tables` in [Pandoc Markdown
 extensions](http://johnmacfarlane.net/pandoc/README.html#tables):
 
-    >>> print(tabulate(table, headers, tablefmt="simple"))
-    item      qty
-    ------  -----
-    spam       42
-    eggs      451
-    bacon       0
+```pycon
+>>> print(tabulate(table, headers, tablefmt="simple"))
+item      qty
+------  -----
+spam       42
+eggs      451
+bacon       0
+```
 
 `github` follows the conventions of GitHub flavored Markdown. It
 corresponds to the `pipe` format without alignment colons:
 
-    >>> print(tabulate(table, headers, tablefmt="github"))
-    | item   | qty   |
-    |--------|-------|
-    | spam   | 42    |
-    | eggs   | 451   |
-    | bacon  | 0     |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="github"))
+| item   | qty   |
+|--------|-------|
+| spam   | 42    |
+| eggs   | 451   |
+| bacon  | 0     |
+```
 
 `grid` is like tables formatted by Emacs'
 [table.el](http://table.sourceforge.net/) package. It corresponds to
 `grid_tables` in Pandoc Markdown extensions:
 
-    >>> print(tabulate(table, headers, tablefmt="grid"))
-    +--------+-------+
-    | item   |   qty |
-    +========+=======+
-    | spam   |    42 |
-    +--------+-------+
-    | eggs   |   451 |
-    +--------+-------+
-    | bacon  |     0 |
-    +--------+-------+
+```pycon
+>>> print(tabulate(table, headers, tablefmt="grid"))
++--------+-------+
+| item   |   qty |
++========+=======+
+| spam   |    42 |
++--------+-------+
+| eggs   |   451 |
++--------+-------+
+| bacon  |     0 |
++--------+-------+
+```
 
 `fancy_grid` draws a grid using box-drawing characters:
 
-    >>> print(tabulate(table, headers, tablefmt="fancy_grid"))
-    ╒════════╤═══════╕
-    │ item   │   qty │
-    ╞════════╪═══════╡
-    │ spam   │    42 │
-    ├────────┼───────┤
-    │ eggs   │   451 │
-    ├────────┼───────┤
-    │ bacon  │     0 │
-    ╘════════╧═══════╛
+```pycon
+>>> print(tabulate(table, headers, tablefmt="fancy_grid"))
+╒════════╤═══════╕
+│ item   │   qty │
+╞════════╪═══════╡
+│ spam   │    42 │
+├────────┼───────┤
+│ eggs   │   451 │
+├────────┼───────┤
+│ bacon  │     0 │
+╘════════╧═══════╛
+```
 
 `presto` is like tables formatted by Presto cli:
 
-    >>> print(tabulate(table, headers, tablefmt="presto"))
-     item   |   qty
-    --------+-------
-     spam   |    42
-     eggs   |   451
-     bacon  |     0
+```pycon
+>>> print(tabulate(table, headers, tablefmt="presto"))
+ item   |   qty
+--------+-------
+ spam   |    42
+ eggs   |   451
+ bacon  |     0
+```
 
 `pretty` attempts to be close to the format emitted by the PrettyTables
 library:
 
-    >>> print(tabulate(table, headers, tablefmt="pretty"))
-    +-------+-----+
-    | item  | qty |
-    +-------+-----+
-    | spam  | 42  |
-    | eggs  | 451 |
-    | bacon |  0  |
-    +-------+-----+
+```pycon
+>>> print(tabulate(table, headers, tablefmt="pretty"))
++-------+-----+
+| item  | qty |
++-------+-----+
+| spam  | 42  |
+| eggs  | 451 |
+| bacon |  0  |
++-------+-----+
+```
 
 `psql` is like tables formatted by Postgres' psql cli:
 
-    >>> print(tabulate(table, headers, tablefmt="psql"))
-    +--------+-------+
-    | item   |   qty |
-    |--------+-------|
-    | spam   |    42 |
-    | eggs   |   451 |
-    | bacon  |     0 |
-    +--------+-------+
+```pycon
+>>> print(tabulate(table, headers, tablefmt="psql"))
++--------+-------+
+| item   |   qty |
+|--------+-------|
+| spam   |    42 |
+| eggs   |   451 |
+| bacon  |     0 |
++--------+-------+
+```
 
 `pipe` follows the conventions of [PHP Markdown
 Extra](http://michelf.ca/projects/php-markdown/extra/#table) extension.
 It corresponds to `pipe_tables` in Pandoc. This format uses colons to
 indicate column alignment:
 
-    >>> print(tabulate(table, headers, tablefmt="pipe"))
-    | item   |   qty |
-    |:-------|------:|
-    | spam   |    42 |
-    | eggs   |   451 |
-    | bacon  |     0 |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="pipe"))
+| item   |   qty |
+|:-------|------:|
+| spam   |    42 |
+| eggs   |   451 |
+| bacon  |     0 |
+```
 
 `orgtbl` follows the conventions of Emacs
 [org-mode](http://orgmode.org/manual/Tables.html), and is editable also
 in the minor orgtbl-mode. Hence its name:
 
-    >>> print(tabulate(table, headers, tablefmt="orgtbl"))
-    | item   |   qty |
-    |--------+-------|
-    | spam   |    42 |
-    | eggs   |   451 |
-    | bacon  |     0 |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="orgtbl"))
+| item   |   qty |
+|--------+-------|
+| spam   |    42 |
+| eggs   |   451 |
+| bacon  |     0 |
+```
 
 `jira` follows the conventions of Atlassian Jira markup language:
 
-    >>> print(tabulate(table, headers, tablefmt="jira"))
-    || item   ||   qty ||
-    | spam   |    42 |
-    | eggs   |   451 |
-    | bacon  |     0 |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="jira"))
+|| item   ||   qty ||
+| spam   |    42 |
+| eggs   |   451 |
+| bacon  |     0 |
+```
 
 `rst` formats data like a simple table of the
 [reStructuredText](http://docutils.sourceforge.net/docs/user/rst/quickref.html#tables)
 format:
 
-    >>> print(tabulate(table, headers, tablefmt="rst"))
-    ======  =====
-    item      qty
-    ======  =====
-    spam       42
-    eggs      451
-    bacon       0
-    ======  =====
+```pycon
+>>> print(tabulate(table, headers, tablefmt="rst"))
+======  =====
+item      qty
+======  =====
+spam       42
+eggs      451
+bacon       0
+======  =====
+```
 
 `mediawiki` format produces a table markup used in
 [Wikipedia](http://www.mediawiki.org/wiki/Help:Tables) and on other
 MediaWiki-based sites:
 
-    >>> print(tabulate(table, headers, tablefmt="mediawiki"))
-    {| class="wikitable" style="text-align: left;"
-    |+ <!-- caption -->
-    |-
-    ! item   !! align="right"|   qty
-    |-
-    | spam   || align="right"|    42
-    |-
-    | eggs   || align="right"|   451
-    |-
-    | bacon  || align="right"|     0
-    |}
+ ```pycon
+>>> print(tabulate(table, headers, tablefmt="mediawiki"))
+{| class="wikitable" style="text-align: left;"
+|+ <!-- caption -->
+|-
+! item   !! align="right"|   qty
+|-
+| spam   || align="right"|    42
+|-
+| eggs   || align="right"|   451
+|-
+| bacon  || align="right"|     0
+|}
+```
 
 `moinmoin` format produces a table markup used in
 [MoinMoin](https://moinmo.in/) wikis:
 
-    >>> print(tabulate(table, headers, tablefmt="moinmoin"))
-    || ''' item   ''' || ''' quantity   ''' ||
-    ||  spam    ||  41.999      ||
-    ||  eggs    ||  451         ||
-    ||  bacon   ||              ||
+```pycon
+>>> print(tabulate(table, headers, tablefmt="moinmoin"))
+|| ''' item   ''' || ''' quantity   ''' ||
+||  spam    ||  41.999      ||
+||  eggs    ||  451         ||
+||  bacon   ||              ||
+```
 
 `youtrack` format produces a table markup used in Youtrack tickets:
 
-    >>> print(tabulate(table, headers, tablefmt="youtrack"))
-    ||  item    ||  quantity   ||
-    |   spam    |  41.999      |
-    |   eggs    |  451         |
-    |   bacon   |              |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="youtrack"))
+||  item    ||  quantity   ||
+|   spam    |  41.999      |
+|   eggs    |  451         |
+|   bacon   |              |
+```
 
 `textile` format produces a table markup used in
 [Textile](http://redcloth.org/hobix.com/textile/) format:
 
-    >>> print(tabulate(table, headers, tablefmt="textile"))
-    |_.  item   |_.   qty |
-    |<. spam    |>.    42 |
-    |<. eggs    |>.   451 |
-    |<. bacon   |>.     0 |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="textile"))
+|_.  item   |_.   qty |
+|<. spam    |>.    42 |
+|<. eggs    |>.   451 |
+|<. bacon   |>.     0 |
+```
 
 `html` produces standard HTML markup as an html.escape'd str
 with a ._repr_html_ method so that Jupyter Lab and Notebook display the HTML
 and a .str property so that the raw HTML remains accessible.
 `unsafehtml` table format can be used if an unescaped HTML is required:
 
-    >>> print(tabulate(table, headers, tablefmt="html"))
-    <table>
-    <tbody>
-    <tr><th>item  </th><th style="text-align: right;">  qty</th></tr>
-    <tr><td>spam  </td><td style="text-align: right;">   42</td></tr>
-    <tr><td>eggs  </td><td style="text-align: right;">  451</td></tr>
-    <tr><td>bacon </td><td style="text-align: right;">    0</td></tr>
-    </tbody>
-    </table>
+```pycon
+>>> print(tabulate(table, headers, tablefmt="html"))
+<table>
+<tbody>
+<tr><th>item  </th><th style="text-align: right;">  qty</th></tr>
+<tr><td>spam  </td><td style="text-align: right;">   42</td></tr>
+<tr><td>eggs  </td><td style="text-align: right;">  451</td></tr>
+<tr><td>bacon </td><td style="text-align: right;">    0</td></tr>
+</tbody>
+</table>
+```
 
 `latex` format creates a `tabular` environment for LaTeX markup,
 replacing special characters like `_` or `\` to their LaTeX
 correspondents:
 
-    >>> print(tabulate(table, headers, tablefmt="latex"))
-    \begin{tabular}{lr}
-    \hline
-     item   &   qty \\
-    \hline
-     spam   &    42 \\
-     eggs   &   451 \\
-     bacon  &     0 \\
-    \hline
-    \end{tabular}
+```pycon
+>>> print(tabulate(table, headers, tablefmt="latex"))
+\begin{tabular}{lr}
+\hline
+ item   &   qty \\
+\hline
+ spam   &    42 \\
+ eggs   &   451 \\
+ bacon  &     0 \\
+\hline
+\end{tabular}
+```
 
 `latex_raw` behaves like `latex` but does not escape LaTeX commands and
 special characters.
@@ -388,50 +442,56 @@ named arguments. Possible column alignments are: `right`, `center`,
 Aligning by a decimal point works best when you need to compare numbers
 at a glance:
 
-    >>> print(tabulate([[1.2345],[123.45],[12.345],[12345],[1234.5]]))
-    ----------
-        1.2345
-      123.45
-       12.345
-    12345
-     1234.5
-    ----------
+```pycon
+>>> print(tabulate([[1.2345],[123.45],[12.345],[12345],[1234.5]]))
+----------
+    1.2345
+  123.45
+   12.345
+12345
+ 1234.5
+----------
+```
 
 Compare this with a more common right alignment:
 
-    >>> print(tabulate([[1.2345],[123.45],[12.345],[12345],[1234.5]], numalign="right"))
-    ------
-    1.2345
-    123.45
-    12.345
-     12345
-    1234.5
-    ------
+```pycon
+>>> print(tabulate([[1.2345],[123.45],[12.345],[12345],[1234.5]], numalign="right"))
+------
+1.2345
+123.45
+12.345
+ 12345
+1234.5
+------
+```
 
 For `tabulate`, anything which can be parsed as a number is a number.
 Even numbers represented as strings are aligned properly. This feature
 comes in handy when reading a mixed table of text and numbers from a
 file:
 
-    >>> import csv ; from StringIO import StringIO
-    >>> table = list(csv.reader(StringIO("spam, 42\neggs, 451\n")))
-    >>> table
-    [['spam', ' 42'], ['eggs', ' 451']]
-    >>> print(tabulate(table))
-    ----  ----
-    spam    42
-    eggs   451
-    ----  ----
-
+```pycon
+>>> import csv ; from StringIO import StringIO
+>>> table = list(csv.reader(StringIO("spam, 42\neggs, 451\n")))
+>>> table
+[['spam', ' 42'], ['eggs', ' 451']]
+>>> print(tabulate(table))
+----  ----
+spam    42
+eggs   451
+----  ----
+```
 
 To disable this feature use `disable_numparse=True`.
 
-    >>> print(tabulate.tabulate([["Ver1", "18.0"], ["Ver2","19.2"]], tablefmt="simple", disable_numparse=True))
-    ----  ----
-    Ver1  18.0
-    Ver2  19.2
-    ----  ----
-
+```pycon
+>>> print(tabulate.tabulate([["Ver1", "18.0"], ["Ver2","19.2"]], tablefmt="simple", disable_numparse=True))
+----  ----
+Ver1  18.0
+Ver2  19.2
+----  ----
+```
 
 ### Custom column alignment
 
@@ -441,30 +501,36 @@ arguments. Possible column alignments are: `right`, `center`, `left`,
 `decimal` (only for numbers), and `None` (to disable alignment).
 Omitting an alignment uses the default. For example:
 
-    >>> print(tabulate([["one", "two"], ["three", "four"]], colalign=("right",))
-    -----  ----
-      one  two
-    three  four
-    -----  ----
+```pycon
+>>> print(tabulate([["one", "two"], ["three", "four"]], colalign=("right",))
+-----  ----
+  one  two
+three  four
+-----  ----
+```
 
 ### Number formatting
 
 `tabulate` allows to define custom number formatting applied to all
 columns of decimal numbers. Use `floatfmt` named argument:
 
-    >>> print(tabulate([["pi",3.141593],["e",2.718282]], floatfmt=".4f"))
-    --  ------
-    pi  3.1416
-    e   2.7183
-    --  ------
+```pycon
+>>> print(tabulate([["pi",3.141593],["e",2.718282]], floatfmt=".4f"))
+--  ------
+pi  3.1416
+e   2.7183
+--  ------
+```
 
 `floatfmt` argument can be a list or a tuple of format strings, one per
 column, in which case every column may have different number formatting:
 
-    >>> print(tabulate([[0.12345, 0.12345, 0.12345]], floatfmt=(".1f", ".3f")))
-    ---  -----  -------
-    0.1  0.123  0.12345
-    ---  -----  -------
+```pycon
+>>> print(tabulate([[0.12345, 0.12345, 0.12345]], floatfmt=(".1f", ".3f")))
+---  -----  -------
+0.1  0.123  0.12345
+---  -----  -------
+```
 
 ### Text formatting
 
@@ -472,8 +538,10 @@ By default, `tabulate` removes leading and trailing whitespace from text
 columns. To disable whitespace removal, set the global module-level flag
 `PRESERVE_WHITESPACE`:
 
-    import tabulate
-    tabulate.PRESERVE_WHITESPACE = True
+```python
+import tabulate
+tabulate.PRESERVE_WHITESPACE = True
+```
 
 ### Wide (fullwidth CJK) symbols
 
@@ -482,15 +550,19 @@ fullwidth glyphs from Chinese, Japanese or Korean languages), the user
 should install `wcwidth` library. To install it together with
 `tabulate`:
 
-    pip install tabulate[widechars]
+```shell
+pip install tabulate[widechars]
+```
 
 Wide character support is enabled automatically if `wcwidth` library is
 already installed. To disable wide characters support without
 uninstalling `wcwidth`, set the global module-level flag
 `WIDE_CHARS_MODE`:
 
-    import tabulate
-    tabulate.WIDE_CHARS_MODE = False
+```python
+import tabulate
+tabulate.WIDE_CHARS_MODE = False
+```
 
 ### Multiline cells
 
@@ -512,134 +584,158 @@ formats may be ambiguous to the reader.
 The following examples of formatted output use the following table with
 a multiline cell, and headers with a multiline cell:
 
-    >>> table = [["eggs",451],["more\nspam",42]]
-    >>> headers = ["item\nname", "qty"]
+```pycon
+>>> table = [["eggs",451],["more\nspam",42]]
+>>> headers = ["item\nname", "qty"]
+```
 
 `plain` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="plain"))
-    item      qty
-    name
-    eggs      451
-    more       42
-    spam
+```pycon
+>>> print(tabulate(table, headers, tablefmt="plain"))
+item      qty
+name
+eggs      451
+more       42
+spam
+```
 
 `simple` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="simple"))
-    item      qty
-    name
-    ------  -----
-    eggs      451
-    more       42
-    spam
+```pycon
+>>> print(tabulate(table, headers, tablefmt="simple"))
+item      qty
+name
+------  -----
+eggs      451
+more       42
+spam
+```
 
 `grid` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="grid"))
-    +--------+-------+
-    | item   |   qty |
-    | name   |       |
-    +========+=======+
-    | eggs   |   451 |
-    +--------+-------+
-    | more   |    42 |
-    | spam   |       |
-    +--------+-------+
+```pycon
+>>> print(tabulate(table, headers, tablefmt="grid"))
++--------+-------+
+| item   |   qty |
+| name   |       |
++========+=======+
+| eggs   |   451 |
++--------+-------+
+| more   |    42 |
+| spam   |       |
++--------+-------+
+```
 
 `fancy_grid` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="fancy_grid"))
-    ╒════════╤═══════╕
-    │ item   │   qty │
-    │ name   │       │
-    ╞════════╪═══════╡
-    │ eggs   │   451 │
-    ├────────┼───────┤
-    │ more   │    42 │
-    │ spam   │       │
-    ╘════════╧═══════╛
+```pycon
+>>> print(tabulate(table, headers, tablefmt="fancy_grid"))
+╒════════╤═══════╕
+│ item   │   qty │
+│ name   │       │
+╞════════╪═══════╡
+│ eggs   │   451 │
+├────────┼───────┤
+│ more   │    42 │
+│ spam   │       │
+╘════════╧═══════╛
+```
 
 `pipe` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="pipe"))
-    | item   |   qty |
-    | name   |       |
-    |:-------|------:|
-    | eggs   |   451 |
-    | more   |    42 |
-    | spam   |       |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="pipe"))
+| item   |   qty |
+| name   |       |
+|:-------|------:|
+| eggs   |   451 |
+| more   |    42 |
+| spam   |       |
+```
 
 `orgtbl` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="orgtbl"))
-    | item   |   qty |
-    | name   |       |
-    |--------+-------|
-    | eggs   |   451 |
-    | more   |    42 |
-    | spam   |       |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="orgtbl"))
+| item   |   qty |
+| name   |       |
+|--------+-------|
+| eggs   |   451 |
+| more   |    42 |
+| spam   |       |
+```
 
 `jira` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="jira"))
-    | item   |   qty |
-    | name   |       |
-    |:-------|------:|
-    | eggs   |   451 |
-    | more   |    42 |
-    | spam   |       |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="jira"))
+| item   |   qty |
+| name   |       |
+|:-------|------:|
+| eggs   |   451 |
+| more   |    42 |
+| spam   |       |
+```
 
 `presto` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="presto"))
-     item   |   qty
-     name   |
-    --------+-------
-     eggs   |   451
-     more   |    42
-     spam   |
+```pycon
+>>> print(tabulate(table, headers, tablefmt="presto"))
+ item   |   qty
+ name   |
+--------+-------
+ eggs   |   451
+ more   |    42
+ spam   |
+```
 
 `pretty` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="pretty"))
-    +------+-----+
-    | item | qty |
-    | name |     |
-    +------+-----+
-    | eggs | 451 |
-    | more | 42  |
-    | spam |     |
-    +------+-----+
+```pycon
+>>> print(tabulate(table, headers, tablefmt="pretty"))
++------+-----+
+| item | qty |
+| name |     |
++------+-----+
+| eggs | 451 |
+| more | 42  |
+| spam |     |
++------+-----+
+```
 
 `psql` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="psql"))
-    +--------+-------+
-    | item   |   qty |
-    | name   |       |
-    |--------+-------|
-    | eggs   |   451 |
-    | more   |    42 |
-    | spam   |       |
-    +--------+-------+
+```pycon
+>>> print(tabulate(table, headers, tablefmt="psql"))
++--------+-------+
+| item   |   qty |
+| name   |       |
+|--------+-------|
+| eggs   |   451 |
+| more   |    42 |
+| spam   |       |
++--------+-------+
+```
 
 `rst` tables:
 
-    >>> print(tabulate(table, headers, tablefmt="rst"))
-    ======  =====
-    item      qty
-    name
-    ======  =====
-    eggs      451
-    more       42
-    spam
-    ======  =====
+```pycon
+>>> print(tabulate(table, headers, tablefmt="rst"))
+======  =====
+item      qty
+name
+======  =====
+eggs      451
+more       42
+spam
+======  =====
+```
 
-Multiline cells are not well supported for the other table formats.
+Multiline cells are not well-supported for the other table formats.
 
 ### Automating Multilines
-While tabulate supports data passed in with multiines entries explicitly provided,
+While tabulate supports data passed in with multilines entries explicitly provided,
 it also provides some support to help manage this work internally.
 
 The `maxcolwidths` argument is a list where each entry specifies the max width for
@@ -652,17 +748,18 @@ and thus no automate multiline wrapping will take place.
 The wraping uses the python standard [textwrap.wrap](https://docs.python.org/3/library/textwrap.html#textwrap.wrap)
 function with default parameters - aside from width.
 
-This example demonstrates usagage of automatic multiline wrapping, though typically
+This example demonstrates usage of automatic multiline wrapping, though typically
 the lines being wrapped would probably be significantly longer than this.
 
-    >>> print(tabulate([["John Smith", "Middle Manager"]], headers=["Name", "Title"], tablefmt="grid", maxcolwidths=[None, 8]))
-    +------------+---------+
-    | Name       | Title   |
-    +============+=========+
-    | John Smith | Middle  |
-    |            | Manager |
-    +------------+---------+
-
+```pycon
+>>> print(tabulate([["John Smith", "Middle Manager"]], headers=["Name", "Title"], tablefmt="grid", maxcolwidths=[None, 8]))
++------------+---------+
+| Name       | Title   |
++============+=========+
+| John Smith | Middle  |
+|            | Manager |
++------------+---------+
+```
 
 
 Usage of the command line utility
@@ -748,22 +845,28 @@ On Linux `tox` expects to find executables like `python2.6`,
 `C:\Python34\python.exe` respectively.
 
 To test only some Python environments, use `-e` option. For example, to
-test only against Python 2.7 and Python 3.8, run:
+test only against Python 3.7 and Python 3.10, run:
 
-    tox -e py27,py38
+```shell
+tox -e py37,py310
+```
 
 in the root of the project source tree.
 
 To enable NumPy and Pandas tests, run:
 
-    tox -e py27-extra,py38-extra
+```shell
+tox -e py37-extra,py310-extra
+```
 
 (this may take a long time the first time, because NumPy and Pandas will
 have to be installed in the new virtual environments)
 
 To fix code formatting:
 
-    tox -e lint
+```shell
+tox -e lint
+```
 
 See `tox.ini` file to learn how to use to test
 individual Python versions.


### PR DESCRIPTION

# Before

![image](https://user-images.githubusercontent.com/1324225/148558096-1dae0b2e-da0b-40f3-b036-5d12f15adc12.png)

https://github.com/astanin/python-tabulate

# After

![image](https://user-images.githubusercontent.com/1324225/148558052-96bf501a-5d10-462c-abf4-e5dce2660569.png)

Preview: https://github.com/hugovk/python-tabulate/tree/readme-formatting
