### PR TITLE
Add caption, label and attributes to 'orgtbl'

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,26 @@ the lines being wrapped would probably be significantly longer than this.
     |            | Manager |
     +------------+---------+
 
+Extensibility
+-------------
 
+The `TableFormat` structure provides for an `extras` function to add
+format-specific arguments to `tabulate()`.  Currently there are two
+functions defined:
+
+1. `def _undefined_kwargs (table_text, abort=False, **kwargs):` to
+   warn about unused extra arguments in the call to `tabulate`
+2. `def _orgtbl_extras (table_text, **kwargs):` for the case of the
+   `'orgtbl'` format, which accepts three optional keyword arguments,
+   which are used in org-mode export to LaTeX:
+   1. `caption` : To add a caption to the table with `#+caption: `
+   2. `label` : To add a label for cross-referencing with `#+label:`
+   3. `attr` : To control the class, positioning, etc. of the table
+   with `#+ATTR_LATEX: `
+   This function takes the table text and prepends the directives
+   requested in the call.
+
+*TODO*: Further `_..._extras` functions can be defined for other table formats.
 
 Usage of the command line utility
 ---------------------------------

--- a/README.md
+++ b/README.md
@@ -271,6 +271,19 @@ in the minor orgtbl-mode. Hence its name:
     | eggs   |   451 |
     | bacon  |     0 |
 
+The table can be further controlled with `label`, `caption` and `attr`:
+
+    >>> print(tabulate(table, headers, tablefmt="orgtbl",
+    ... label='test-tbl', caption='A test table', attr=':placement [H]'))
+    #+caption: A test table}
+    #+label: test-tbl
+    #+ATTR_LATEX: :placement [H]
+    | item   |   qty |
+    |--------+-------|
+    | spam   |    42 |
+    | eggs   |   451 |
+    | bacon  |     0 |
+
 `jira` follows the conventions of Atlassian Jira markup language:
 
     >>> print(tabulate(table, headers, tablefmt="jira"))

--- a/tabulate.py
+++ b/tabulate.py
@@ -1708,11 +1708,12 @@ def tabulate(
         minwidths = [max(width_fn(cl) for cl in c) for c in cols]
         rows = list(zip(*cols))
 
+    _is_orgtbl = tablefmt == 'orgtbl'
     if not isinstance(tablefmt, TableFormat):
         tablefmt = _table_formats.get(tablefmt, _table_formats["simple"])
 
     result = ''
-    if tablefmt == 'orgtbl':
+    if _is_orgtbl:
         #
         # add additional org-mode headers to control the format
         # of the generated table

--- a/tabulate.py
+++ b/tabulate.py
@@ -63,7 +63,7 @@ except ImportError:
 
 
 __all__ = ["tabulate", "tabulate_formats", "simple_separated_format"]
-__version__ = "0.8.10"
+__version__ = "0.8.10a"
 
 
 # minimum extra space in headers
@@ -308,9 +308,9 @@ def _orgtbl_extras (table_text, **kwargs):
     caption = kwargs.pop('caption',None)
     label   = kwargs.pop('label',None)
     attr    = kwargs.pop('attr',None)
-    result = '' if caption is None else '#+caption: '+caption+'}\n'
-    if label is not None: result += f'#+label: '+label+'\n'
-    if attr is not None: result += f'#+ATTR_LATEX: {attr}\n'
+    result = '' if caption is None else '#+caption: '+caption+'\n'
+    if label is not None: result += '#+label: '+label+'\n'
+    if attr is not None: result += '#+ATTR_LATEX: '+attr+'\n'
 
     return _undefined_kwargs(result + table_text,**kwargs)
 

--- a/tabulate.py
+++ b/tabulate.py
@@ -305,14 +305,11 @@ def _orgtbl_extras (table_text, **kwargs):
     # add additional org-mode headers to control the format
     # of the generated table
     #
-    caption = kwargs.pop('caption',None)
-    label   = kwargs.pop('label',None)
-    attr    = kwargs.pop('attr_latex',None)
-    result = '' if caption is None else '#+caption: '+caption+'\n'
-    if label is not None: result += '#+label: '+label+'\n'
-    if attr is not None: result += '#+ATTR_LATEX: '+attr+'\n'
-
-    return _undefined_kwargs(result + table_text,**kwargs)
+    result = ''
+    for kw in ['caption','label','attr_latex']:
+        value = kwargs.pop(kw, None)
+        if value is not None: result += f'#+{kw.upper()}: {value}'
+    return _undefined_kwargs(result + table_text, **kwargs)
 
 _table_formats = {
     "simple": TableFormat(

--- a/tabulate.py
+++ b/tabulate.py
@@ -307,7 +307,7 @@ def _orgtbl_extras (table_text, **kwargs):
     #
     caption = kwargs.pop('caption',None)
     label   = kwargs.pop('label',None)
-    attr    = kwargs.pop('attr',None)
+    attr    = kwargs.pop('attr_latex',None)
     result = '' if caption is None else '#+caption: '+caption+'\n'
     if label is not None: result += '#+label: '+label+'\n'
     if attr is not None: result += '#+ATTR_LATEX: '+attr+'\n'

--- a/tabulate.py
+++ b/tabulate.py
@@ -308,7 +308,7 @@ def _orgtbl_extras (table_text, **kwargs):
     result = ''
     for kw in ['caption','label','attr_latex']:
         value = kwargs.pop(kw, None)
-        if value is not None: result += f'#+{kw.upper()}: {value}'
+        if value is not None: result += f'#+{kw.upper()}: {value}\n'
     return _undefined_kwargs(result + table_text, **kwargs)
 
 _table_formats = {

--- a/tabulate.py
+++ b/tabulate.py
@@ -1251,6 +1251,9 @@ def tabulate(
     disable_numparse=False,
     colalign=None,
     maxcolwidths=None,
+        caption = None,
+        label = None,
+        attr = None,
 ):
     """Format a fixed width table for pretty printing.
 
@@ -1435,6 +1438,23 @@ def tabulate(
     | spam      |   41.9999 |
     | eggs      |  451      |
 
+    Additionally you can control the prelude to the table with arguments
+    caption, label and attr
+
+    >>> tabulate(df,
+    ...     caption='extended tabulate',
+    ...     label='labextend',
+    ...     attr=':environment longtable :align p{2cm}p{3cm}p{3cm} :placement [h] :center t',
+    ...     headers=df.columns, tablefmt='orgtbl',
+    ...     showindex=False)
+    #+caption: extended tabulate
+    #+label: labextend
+    #+ATTR_LATEX: :environment longtable :align p{2cm}p{3cm}p{3cm} :placement [h] :center t
+    |        x |       sin(x) |    cos(x) |
+    |----------+--------------+-----------|
+    | 0        |  0           |  1        |
+    | 0.628319 |  0.587785    |  0.809017 |
+    | 1.25664  |  0.951057    |  0.309017 |
 
     >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]], tablefmt="orgtbl"))
     | spam |  41.9999 |
@@ -1691,7 +1711,17 @@ def tabulate(
     if not isinstance(tablefmt, TableFormat):
         tablefmt = _table_formats.get(tablefmt, _table_formats["simple"])
 
-    return _format_table(tablefmt, headers, rows, minwidths, aligns, is_multiline)
+    result = ''
+    if tablefmt == 'orgtbl':
+        #
+        # add additional org-mode headers to control the format
+        # of the generated table
+        #
+        result = '' if caption is None else '#+caption: '+caption+'}\n'
+        if label is not None: result += f'#+label: '+label+'\n'
+        if attr is not None: result += f'#+ATTR_LATEX: {attr}\n'
+
+    return result + _format_table(tablefmt, headers, rows, minwidths, aligns, is_multiline)
 
 
 def _expand_numparse(disable_numparse, column_count):

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@
 # for testing and it is disabled by default.
 
 [tox]
-envlist = lint, py27, py35, py36, py37, py38, py39, py310
+# envlist = lint, py27, py35, py36, py37, py38, py39, py310
+envlist = lint, py38
 
 [testenv]
 commands = pytest -v --doctest-modules --ignore benchmark.py


### PR DESCRIPTION
This patch gives more control over how tables for org-mode are generated. 

Note (for me): A low-hanging fruit might be LaTeX