### PR TITLE
fix decimal precision issue

### DIFF
--- a/tabulate.py
+++ b/tabulate.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 from collections import namedtuple
+from decimal import Decimal
 import sys
 import re
 import math
@@ -996,7 +997,7 @@ def _format(val, valtype, floatfmt, missingval="", has_invisible=True):
             formatted_val = format(float(raw_val), floatfmt)
             return val.replace(raw_val, formatted_val)
         else:
-            return format(float(val), floatfmt)
+            return format(Decimal(val), floatfmt)
     else:
         return "{0}".format(val)
 


### PR DESCRIPTION
I was having issues where a `Decimal` object was being outputted incorrectly in the table - the value was `99999998999.999980` and `tabulate` was called with `floatfmt=",.6f"`, and the output in that cell was `99,999,998,999.999985`. This PR fixes that problem.