### PR TITLE
Fix multiline folding of table formats rendering unseparated cells

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -699,6 +699,13 @@ multiline_formats = {
     "pretty": "pretty",
     "psql": "psql",
     "rst": "rst",
+    "outline": "outline",
+    "simple_outline": "simple_outline",
+    "rounded_outline": "rounded_outline",
+    "heavy_outline": "heavy_outline",
+    "mixed_outline": "mixed_outline",
+    "double_outline": "double_outline",
+    "fancy_outline": "fancy_outline",
 }
 
 # TODO: Add multiline support for the remaining table formats:


### PR DESCRIPTION
All `*_outline` table formats have been broken since their inceptions:
```
>>> import tabulate
>>> tabulate.__version__
'0.8.8'

>>> print(tabulate([["a\nbb", "a\nbb\nccc\ndddd"]], tablefmt="fancy_outline"))
╒═╤═╕
│ a
bb  │ a
bb
ccc
dddd  │
╘═╧═╛
```

The correct rendering we are looking for is:
```
>>> print(tabulate([["a\nbb", "a\nbb\nccc\ndddd"]], tablefmt="fancy_outline"))
╒════╤══════╕
│ a  │ a    │
│ bb │ bb   │
│    │ ccc  │
│    │ dddd │
╘════╧══════╛
```

The problem is that we forgot to reference all these formats in the hard-coded [`tabulate.multiline_formats`](https://github.com/astanin/python-tabulate/blob/50ec140b4154307c285b4454a3ac305041de8d19/tabulate/__init__.py#L682-L712) variable.

Refs #80. Closes #203.