### PR TITLE
Replace deprecated HTML

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -136,9 +136,9 @@ def _pipe_line_with_colons(colwidths, colaligns):
 def _mediawiki_row_with_attrs(separator, cell_values, colwidths, colaligns):
     alignment = {
         "left": "",
-        "right": 'align="right"| ',
-        "center": 'align="center"| ',
-        "decimal": 'align="right"| ',
+        "right": 'style="text-align: right;"| ',
+        "center": 'style="text-align: center;"| ',
+        "decimal": 'style="text-align: right;"| ',
     }
     # hard-coded padding _around_ align attribute and value together
     # rather than padding parameter which affects only the value
@@ -1952,11 +1952,11 @@ def tabulate(
     {| class="wikitable" style="text-align: left;"
     |+ <!-- caption -->
     |-
-    ! strings   !! align="right"|   numbers
+    ! strings   !! style="text-align: right;"|   numbers
     |-
-    | spam      || align="right"|   41.9999
+    | spam      || style="text-align: right;"|   41.9999
     |-
-    | eggs      || align="right"|  451
+    | eggs      || style="text-align: right;"|  451
     |}
 
     "html" produces HTML markup as an html.escape'd str

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -2322,11 +2322,11 @@ def test_mediawiki():
             '{| class="wikitable" style="text-align: left;"',
             "|+ <!-- caption -->",
             "|-",
-            '! strings   !! align="right"|   numbers',
+            '! strings   !! style="text-align: right;"|   numbers',
             "|-",
-            '| spam      || align="right"|   41.9999',
+            '| spam      || style="text-align: right;"|   41.9999',
             "|-",
-            '| eggs      || align="right"|  451',
+            '| eggs      || style="text-align: right;"|  451',
             "|}",
         ]
     )
@@ -2341,9 +2341,9 @@ def test_mediawiki_headerless():
             '{| class="wikitable" style="text-align: left;"',
             "|+ <!-- caption -->",
             "|-",
-            '| spam || align="right"|  41.9999',
+            '| spam || style="text-align: right;"|  41.9999',
             "|-",
-            '| eggs || align="right"| 451',
+            '| eggs || style="text-align: right;"| 451',
             "|}",
         ]
     )


### PR DESCRIPTION
As stated on [wikipedia:WP:HTML5](https://en.wikipedia.org/wiki/Wikipedia:HTML_5), all instances of `align="center"` or `align="right"` must be replaced with `style="text-align: center;"` or `style="text-align: right;"`, respectively, to align text.