### PR TITLE
Fix bug/issue #231: SEPARATING_LINE feature doesn't work when the requested format pads columns

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -101,12 +101,17 @@ TableFormat = namedtuple(
 )
 
 
+def _is_separating_line_value(value):
+    return type(value) == str and value.strip() == SEPARATING_LINE
+
+
 def _is_separating_line(row):
     row_type = type(row)
     is_sl = (row_type == list or row_type == str) and (
-        (len(row) >= 1 and row[0] == SEPARATING_LINE)
-        or (len(row) >= 2 and row[1] == SEPARATING_LINE)
+        (len(row) >= 1 and _is_separating_line_value(row[0]))
+        or (len(row) >= 2 and _is_separating_line_value(row[1]))
     )
+
     return is_sl
 
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -2881,6 +2881,27 @@ def test_list_of_lists_with_index_with_sep_line():
     assert_equal(expected, result)
 
 
+def test_with_padded_columns_with_sep_line():
+    table = [
+        ["1", "one"],  # "1" as a str on purpose
+        [1_000, "one K"],
+        SEPARATING_LINE,
+        [1_000_000, "one M"],
+    ]
+    expected = "\n".join(
+        [
+            "+---------+-------+",
+            "|       1 | one   |",
+            "|    1000 | one K |",
+            "|---------+-------|",
+            "| 1000000 | one M |",
+            "+---------+-------+",
+        ]
+    )
+    result = tabulate(table, tablefmt="psql")
+    assert_equal(expected, result)
+
+
 def test_list_of_lists_with_supplied_index():
     "Output: a table with a supplied index"
     dd = zip(*[list(range(3)), list(range(101, 104))])


### PR DESCRIPTION
The subject says it all.. 😉 
Tested:
```
lint: OK (6.63=setup[4.07]+cmd[2.56] seconds)
  py37: OK (5.15=setup[3.97]+cmd[1.19] seconds)
  py38: OK (4.83=setup[3.63]+cmd[1.20] seconds)
  py39: OK (4.42=setup[3.28]+cmd[1.14] seconds)
  py310: OK (4.77=setup[3.57]+cmd[1.20] seconds)
  py311: OK (4.59=setup[3.34]+cmd[1.25] seconds)
  congratulations :) (30.46 seconds)
```
