### PR TITLE
Fix #135. Get rid of exceptions when converting values to numbers.

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1224,10 +1224,15 @@ def _format(val, valtype, floatfmt, intfmt, missingval="", has_invisible=True):
     """  # noqa
     if val is None:
         return missingval
-
+    if _isbool(val):
+        # val should be a boolean literal to convert into a number if needed
+        val = val in (True, "True")
     if valtype is str:
         return f"{val}"
     elif valtype is int:
+        # do not convert strings and bools into integers if there is no special formatting
+        if intfmt:
+            val = int(val)
         return format(val, intfmt)
     elif valtype is bytes:
         try:

--- a/test/test_input.py
+++ b/test/test_input.py
@@ -50,6 +50,27 @@ def test_iterable_of_iterables_firstrow():
     assert_equal(expected, result)
 
 
+def test_mixed_bools():
+    "Input: a list of lists with mixed number and bool values."
+    ll = [
+        ["1.1", "1000", "1000"],
+        [True, True, True],
+        ["False", "False", "False"],
+    ]
+    # notice INCONSISTENCY in boolean representation
+    expected = "\n".join(
+        [
+            "---  -----  -----",
+            "1.1   1000  1,000",
+            "1.0   True      1",
+            "0.0  False      0",
+            "---  -----  -----",
+        ]
+    )
+    result = tabulate(ll, floatfmt=".1f", intfmt=("", "", ","))
+    assert_equal(expected, result)
+
+
 def test_list_of_lists():
     "Input: a list of lists with headers."
     ll = [["a", "one", 1], ["b", "two", None]]


### PR DESCRIPTION
Fix #135

- [x] Add the test to check for exceptions
- [x] Fix for booleans to float conversion
- [x] Fix for booleans and strings formatted as integers

Note: there is (and has been for a while as I understand it) an inconsistency in boolean representation in the columns which contain a mix of bools and numbers. Booleans were passed as text in case of unformatted integer column type, and converted into [0, 1] otherwise. For example:
```pycon
>>> print(tabulate([[1.1, 1], [True, True]]))
---  ----
1.1     1
1    True
---  ----
```
This behavior is PRESERVED in the current fix, no breaking changes introduced, just "True" and True are handled in the same way now.

This pull request is still a draft because I found another issue which would possibly be wise to fix here since it also concerns the _format function. 