### PR TITLE
Treat empty strings as generic for column type deduction, allow thousands separators

### DIFF
--- a/test/test_output.py
+++ b/test/test_output.py
@@ -2824,6 +2824,13 @@ def test_floatfmt():
     assert_equal(expected, result)
 
 
+def test_floatfmt_thousands():
+    "Output: floating point format"
+    result = tabulate([["1.23456789"], [1.0], ["1,234.56"]], floatfmt=".3f", tablefmt="plain")
+    expected = "   1.235\n   1.000\n1234.560"
+    assert_equal(expected, result)
+
+
 def test_floatfmt_multi():
     "Output: floating point format different for each column"
     result = tabulate(
@@ -2961,6 +2968,32 @@ def test_missingval_multi():
         tablefmt="plain",
     )
     expected = "Alice  Bob  Charlie\nn/a    ?"
+    assert_equal(expected, result)
+
+
+def test_column_emptymissing_deduction():
+    "Missing or empty/blank values shouldn't change type deduction of rest of column"
+    from fractions import Fraction
+
+    test_table = [
+        [None, "1.23423515351", Fraction(1, 3)],
+        [Fraction(56789, 1000000), 12345.1, b"abc"],
+        ["", b"", None],
+        [Fraction(10000, 3), None, ""],
+    ]
+    result = tabulate(
+        test_table,
+        floatfmt=",.5g",
+        missingval="?",
+    )
+    print(f"\n{result}")
+    expected = """\
+------------  -----------  ---
+    ?              1.2342  1/3
+    0.056789  12,345       abc
+                           ?
+3,333.3            ?
+------------  -----------  ---"""
     assert_equal(expected, result)
 
 


### PR DESCRIPTION
Allow missing (None) and empty ("") cells to be treated the same, for the purposes of deducing the column type.

This allows us to have empty cells (without the `missingval`), differentiated from missing cells (with the `missingval`), for columns generally containing numeric data, while retaining the correctly deduced column formatting.

Resolves #242