### PR TITLE
Fix headers for list of dicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,35 @@ Alice      24
 Bob        19
 ```
 
+When the data is a list of dict, `headers="firstrow"` can also be 
+used to assign different column names to each corresponding dict key:
+
+```pycon
+>>> print(tabulate([{"name": "Name", "age": "Age"}, 
+                    {"name": "Alice", "age": 24},
+                    {"name": "Bob", "age": 19}],
+                    headers="firstrow"))
+Name      Age
+------  -----
+Alice      24
+Bob        19
+```
+
+Furthermore with a list of dict, you can also specify `headers` as 
+a dict (similar to the example above), or as a list of keys. Either way,
+the specified keys can be a subset of all the keys present across the 
+dataset:
+
+```pycon
+>>> print(tabulate([{"foo": 1, "bar": 2},
+                    {"foo": 3, "bar": 4, "baz": 5}],
+                    headers=["bar","foo"]))
+bar    foo
+-----  -----
+    2      1
+    4      3
+```
+
 If `headers="keys"`, then the keys of a dictionary/dataframe, or column
 indices are used. It also works for NumPy record arrays and lists of
 dictionaries or named tuples:


### PR DESCRIPTION
This contribution corrects the behavior of the `headers` option when the input data is a list of dict.

1. Fix the behavior of `headers="firstrow"`. The example below illustrates the current behavior, which is incorrect:
```
x = [ {'b': 'B', 'a': 'A'}, 
      {'a': 1, 'b': 2}, 
      {'a': 3, 'b': 4, 'c': 5} ]

print(tabulate( x, headers='firstrow' ))

# Current output:
#
#   B    A    c
# ---  ---  ---
#   2    1
#   4    3    5

# Proposed output:
#
#   B    A
# ---  ---
#   2    1
#   4    3
```

2. Fix the current behavior when `headers` is specified as a list of keys:

```
x = [ {'a': 1, 'b': 2}, 
      {'a': 3, 'b': 4, 'c': 5} ]

print(tabulate( x, headers=['b','a'] ))

# Current output:
#
#       b    a
# --  ---  ---
#  1    2
#  3    4    5

# Proposed output:
#
#   b    a
# ---  ---
#   2    1
#   4    3
```
