### PR TITLE
Update _isnumber to ensure the output string convertible to float

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -850,7 +850,7 @@ def _isnumber(string):
     >>> _isnumber("inf")
     True
     """
-    if not _isconvertible(float, string):
+    if not _isconvertible(float, str(string)):
         return False
     elif isinstance(string, (str, bytes)) and (
         math.isinf(float(string)) or math.isnan(float(string))


### PR DESCRIPTION
The numpy.datetime64[ns] was recognized as float, because numpy.datetime64[ns] is convertible to float. This PR fixes this problem ( related issue #251 ).