### PR TITLE
Bugfix in tables without linebetweenrows

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -2376,13 +2376,14 @@ def _format_table(fmt, headers, rows, colwidths, colaligns, is_multiline, rowali
         if fmt.linebelowheader and "linebelowheader" not in hidden:
             _append_line(lines, padded_widths, colaligns, fmt.linebelowheader)
 
-    if padded_rows and fmt.linebetweenrows and "linebetweenrows" not in hidden:
+    if padded_rows:
         # initial rows with a line below
         for row, ralign in zip(padded_rows[:-1], rowaligns):
             append_row(
                 lines, row, padded_widths, colaligns, fmt.datarow, rowalign=ralign
             )
-            _append_line(lines, padded_widths, colaligns, fmt.linebetweenrows)
+            if fmt.linebetweenrows and "linebetweenrows" not in hidden:
+                _append_line(lines, padded_widths, colaligns, fmt.linebetweenrows)
         # the last row without a line below
         append_row(
             lines,
@@ -2392,21 +2393,7 @@ def _format_table(fmt, headers, rows, colwidths, colaligns, is_multiline, rowali
             fmt.datarow,
             rowalign=rowaligns[-1],
         )
-    else:
-        separating_line = (
-            fmt.linebetweenrows
-            or fmt.linebelowheader
-            or fmt.linebelow
-            or fmt.lineabove
-            or Line("", "", "", "")
-        )
-        for row in padded_rows:
-            # test to see if either the 1st column or the 2nd column (account for showindex) has
-            # the SEPARATING_LINE flag
-            if _is_separating_line(row):
-                _append_line(lines, padded_widths, colaligns, separating_line)
-            else:
-                append_row(lines, row, padded_widths, colaligns, fmt.datarow)
+
 
     if fmt.linebelow and "linebelow" not in hidden:
         _append_line(lines, padded_widths, colaligns, fmt.linebelow)


### PR DESCRIPTION
Before
```
╭───────┬──────────────────────────────────────────────╮
│       │ File: /tmp/teste.json                        │
├───────┼──────────────────────────────────────────────┤
│    1  │ {                                            │
│    2  │   "id":
"d35c4561-abb3-4fa5-8103-c0a88ca9eb50",                                              │
│    3  │   "name": "CCat Test",                       │
│    4  │   "values": [                                │
│    5  │     {                                        │
│    6  │       "key": "url",                          │
│    7  │       "value": "",                           │
│    8  │       "enabled": true                        │
│    9  │     }                                        │
│   10  │   ],                                         │
│   11  │   "_postman_variable_scope": "environment",  │
│   12  │   "_postman_exported_at":
"2019-10-24T12:33:17.368Z",                                              │
│   13  │   "_postman_exported_using": "Postman/7.9.0" │
│   14  │ }                                            │
╰───────┴──────────────────────────────────────────────╯
```

After
```
╭───────┬──────────────────────────────────────────────╮
│       │ File: /tmp/teste.json                        │
├───────┼──────────────────────────────────────────────┤
│    1  │ {                                            │
│    2  │   "id":                                      │
│       │ "d35c4561-abb3-4fa5-8103-c0a88ca9eb50",      │
│    3  │   "name": "CCat Test",                       │
│    4  │   "values": [                                │
│    5  │     {                                        │
│    6  │       "key": "url",                          │
│    7  │       "value": "",                           │
│    8  │       "enabled": true                        │
│    9  │     }                                        │
│   10  │   ],                                         │
│   11  │   "_postman_variable_scope": "environment",  │
│   12  │   "_postman_exported_at":                    │
│       │ "2019-10-24T12:33:17.368Z",                  │
│   13  │   "_postman_exported_using": "Postman/7.9.0" │
│   14  │ }                                            │
╰───────┴──────────────────────────────────────────────╯
```