### PR TITLE
Renders GitHub-Flavored Markdown tables in canonical format

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ corresponds to the `pipe` format without alignment colons:
 ```pycon
 >>> print(tabulate(table, headers, tablefmt="github"))
 | item   | qty   |
-|--------|-------|
+| ------ | ----- |
 | spam   | 42    |
 | eggs   | 451   |
 | bacon  | 0     |

--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -470,13 +470,13 @@ _table_formats = {
         with_header_hide=None,
     ),
     "github": TableFormat(
-        lineabove=Line("|", "-", "|", "|"),
-        linebelowheader=Line("|", "-", "|", "|"),
+        lineabove=Line("| ", "-", " | ", " |"),
+        linebelowheader=Line("| ", "-", " | ", " |"),
         linebetweenrows=None,
         linebelow=None,
-        headerrow=DataRow("|", "|", "|"),
-        datarow=DataRow("|", "|", "|"),
-        padding=1,
+        headerrow=DataRow("| ", " | ", " |"),
+        datarow=DataRow("| ", " | ", " |"),
+        padding=0,
         with_header_hide=["lineabove"],
     ),
     "pipe": TableFormat(
@@ -1884,6 +1884,15 @@ def tabulate(
     │ spam      │   41.9999 │
     │ eggs      │  451      │
     ╘═══════════╧═══════════╛
+
+    "github" is the Github-Flavored Markdown syntax:
+
+    >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]],
+    ...                ["strings", "numbers"], "github"))
+    | strings   |   numbers |
+    | --------- | --------- |
+    | spam      |   41.9999 |
+    | eggs      |  451      |
 
     "pipe" is like tables in PHP Markdown Extra extension or Pandoc
     pipe_tables:

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -429,7 +429,7 @@ def test_github():
     expected = "\n".join(
         [
             "| strings   |   numbers |",
-            "|-----------|-----------|",
+            "| --------- | --------- |",
             "| spam      |   41.9999 |",
             "| eggs      |  451      |",
         ]


### PR DESCRIPTION
[In the GitHub Flavored Markdown Spec, tables are formatted in all sorts of shapes](https://github.github.com/gfm/#tables-extension-).

But one common aspect is that the pipes separating the cells are padded by a space. This is acknowledged in `python-tabulate` with the `padding=1` settings. But unfortunately this setting doesn't applies to the `lineabove` and `linebelowheader` lines.

This PR fixes this issue, by having the line separators renders with padding spaces between the pipes and dashes.