### PR TITLE
Fix separating line detection with ndarray values

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -105,8 +105,8 @@ TableFormat = namedtuple(
 def _is_separating_line(row):
     row_type = type(row)
     is_sl = (row_type == list or row_type == str) and (
-        (len(row) >= 1 and row[0] == SEPARATING_LINE)
-        or (len(row) >= 2 and row[1] == SEPARATING_LINE)
+        (len(row) >= 1 and row[0] is SEPARATING_LINE)
+        or (len(row) >= 2 and row[1] is SEPARATING_LINE)
     )
     return is_sl
 


### PR DESCRIPTION
This code:

```python
import numpy as np
from tabulate import tabulate

data = [[np.ones(1)]]

print(tabulate(data))
```

Throws a `FutureWarning` or a `ValueError` due to the comparison with `SEPARATING_LINE`. 


Fixes https://github.com/astanin/python-tabulate/issues/287