### PR TITLE
Fix TypeError when using a tuple for maxcolwidths #214

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,5 +1123,5 @@ Bart Broere, Vilhelm Prytz, Alexander Gažo, Hugo van Kemenade,
 jamescooke, Matt Warner, Jérôme Provensal, Kevin Deldycke,
 Kian-Meng Ang, Kevin Patterson, Shodhan Save, cleoold, KOLANICH,
 Vijaya Krishna Kasula, Furcy Pin, Christian Fibich, Shaun Duncan,
-Dimitri Papadopoulos, Racerroar.
+Dimitri Papadopoulos, Élie Goudout, Racerroar, Phill Zarfos.
 

--- a/README.md
+++ b/README.md
@@ -1123,5 +1123,5 @@ Bart Broere, Vilhelm Prytz, Alexander Gažo, Hugo van Kemenade,
 jamescooke, Matt Warner, Jérôme Provensal, Kevin Deldycke,
 Kian-Meng Ang, Kevin Patterson, Shodhan Save, cleoold, KOLANICH,
 Vijaya Krishna Kasula, Furcy Pin, Christian Fibich, Shaun Duncan,
-Dimitri Papadopoulos.
+Dimitri Papadopoulos, Racerroar.
 

--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -2071,6 +2071,8 @@ def tabulate(
     list_of_lists, separating_lines = _remove_separating_lines(list_of_lists)
 
     if maxcolwidths is not None:
+        if type(maxcolwidths) is tuple:  # Check if tuple, convert to list if so
+            maxcolwidths = list(maxcolwidths)
         if len(list_of_lists):
             num_cols = len(list_of_lists[0])
         else:


### PR DESCRIPTION
This PR fixes issue [#214](https://github.com/astanin/python-tabulate/issues/214)

Issue:
- When you used a tuple for maxcolwidths, it caused an `TypeError` error.

PR:
- The original PR [#215](https://github.com/astanin/python-tabulate/pull/215) created by [Racerroar888](https://github.com/Racerroar888) was closed without merging, because of a merge conflict   
- This new PR includes the original code fix, a unit test, and fixes the merge conflict.
