### PR TITLE
Fix column wrapping breaking ANSI escape codes (fixes #307)

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -2540,16 +2540,19 @@ class _CustomTextWrap(textwrap.TextWrapper):
             # take each charcter's width into account
             chunk = reversed_chunks[-1]
             i = 1
+            # Only count printable characters, so strip_ansi first, index later.
             while len(_strip_ansi(chunk)[:i]) <= space_left:
                 i = i + 1
             # Consider escape codes when breaking words up
             total_escape_len = 0
+            last_group = 0
             if _ansi_codes.search(chunk) is not None:
                 for group, _, _, _ in _ansi_codes.findall(chunk):
                     escape_len = len(group)
-                    # FIXME: Needs to keep track of found groups and search from there
-                    if group in chunk[: i  + total_escape_len + escape_len - 1]:
+                    if group in chunk[last_group: i + total_escape_len + escape_len - 1]:
                         total_escape_len += escape_len
+                        found = _ansi_codes.search(chunk[last_group:])
+                        last_group += found.end()
             cur_line.append(chunk[: i  + total_escape_len - 1])
             reversed_chunks[-1] = chunk[i + total_escape_len - 1 :]
 

--- a/test/common.py
+++ b/test/common.py
@@ -3,8 +3,8 @@ from pytest import skip, raises  # noqa
 import warnings
 
 def assert_equal(expected, result):
-    print("Expected:\n%s\n" % expected)
-    print("Got:\n%s\n" % result)
+    print("Expected:\n%r\n" % expected)
+    print("Got:\n%r\n" % result)
     assert expected == result
 
 

--- a/test/test_textwrapper.py
+++ b/test/test_textwrapper.py
@@ -177,22 +177,22 @@ def test_wrap_color_line_longword():
 
 
 def test_wrap_color_line_multiple_escapes():
-    data = '012345(\x1b[32ma\x1b[0mbc\x1b[32mdefghij\x1b[0m)'
+    data = "012345(\x1b[32ma\x1b[0mbc\x1b[32mdefghij\x1b[0m)"
     expected = [
-        "012345(\x1b[32ma\x1b[0mbc\x1b[32mdefg\x1b[0m",
-        "\x1b[32mhij\x1b[0m)",
+        "012345(\x1b[32ma\x1b[0mbc\x1b[32m\x1b[0m",
+        "\x1b[32mdefghij\x1b[0m)",
     ]
     wrapper = CTW(width=10)
     result = wrapper.wrap(data)
     assert_equal(expected, result)
+
     clean_data = _strip_ansi(data)
     for width in range(2, len(clean_data)):
-        # Currently fails with 14, 15 and 16, because a escape code gets split at the end
         wrapper = CTW(width=width)
         result = wrapper.wrap(data)
-        # print(width, result)
         # Comparing after stripping ANSI should be enough to catch broken escape codes
         assert_equal(clean_data, _strip_ansi("".join(result)))
+
 
 def test_wrap_datetime():
     """TextWrapper: Show that datetimes can be wrapped without crashing"""

--- a/test/test_textwrapper.py
+++ b/test/test_textwrapper.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import datetime
 
-from tabulate import _CustomTextWrap as CTW, tabulate
+from tabulate import _CustomTextWrap as CTW, tabulate, _strip_ansi
 from textwrap import TextWrapper as OTW
 
 from common import skip, assert_equal
@@ -157,6 +157,42 @@ def test_wrap_color_line_splillover():
     result = wrapper.wrap(data)
     assert_equal(expected, result)
 
+
+def test_wrap_color_line_longword():
+    """TextWrapper: Wrap a line - preserve internal color tags and wrap them to
+    other lines when required, requires adding the colors tags to other lines as appropriate
+    and avoiding splitting escape codes."""
+    data = "This_is_a_\033[31mtest_string_for_testing_TextWrap\033[0m_with_colors"
+
+    expected = [
+        "This_is_a_\033[31mte\033[0m",
+        "\033[31mst_string_fo\033[0m",
+        "\033[31mr_testing_Te\033[0m",
+        "\033[31mxtWrap\033[0m_with_",
+        "colors",
+    ]
+    wrapper = CTW(width=12)
+    result = wrapper.wrap(data)
+    assert_equal(expected, result)
+
+
+def test_wrap_color_line_multiple_escapes():
+    data = '012345(\x1b[32ma\x1b[0mbc\x1b[32mdefghij\x1b[0m)'
+    expected = [
+        "012345(\x1b[32ma\x1b[0mbc\x1b[32mdefg\x1b[0m",
+        "\x1b[32mhij\x1b[0m)",
+    ]
+    wrapper = CTW(width=10)
+    result = wrapper.wrap(data)
+    assert_equal(expected, result)
+    clean_data = _strip_ansi(data)
+    for width in range(2, len(clean_data)):
+        # Currently fails with 14, 15 and 16, because a escape code gets split at the end
+        wrapper = CTW(width=width)
+        result = wrapper.wrap(data)
+        # print(width, result)
+        # Comparing after stripping ANSI should be enough to catch broken escape codes
+        assert_equal(clean_data, _strip_ansi("".join(result)))
 
 def test_wrap_datetime():
     """TextWrapper: Show that datetimes can be wrapped without crashing"""


### PR DESCRIPTION
In `tabulate._CustomTextWrap._handle_long_word`, ANSI escape codes may be broken in the middle, resulting wrongly formatted tables. That happens because the length of the string is checked in `while self._len(chunk[:i]) <= space_left:`, which may strip ANSI codes after they were broken by indexing into their middle.

To solve that, we instead calculate the length of the string without ANSI codes, then index into it: `while len(_strip_ansi(chunk)[:i]) <= space_left:`. That gives the amount of printable characters that should be included. Then we iterate through the escape codes present until we reach that many printable characters, and add the escape code lengths to figure out how much of the original string should be included. 

Tests included.

Test code:
```python
import tabulate
print(tabulate.tabulate(tabular_data=(('012345 (\x1b[32mabcdefghij\x1b[0m)', 'XX'),), maxcolwidths=11, tablefmt='grid'))"
```

Result before patch:
```
+-------------+----+
| 012345 ( XX |
| 2mabcdefghi |    |
| j)          |    |
+-------------+----+
```
![broken_tabulate-color_wrap](https://github.com/astanin/python-tabulate/assets/74280297/40ce50bb-6eb5-4223-84c3-7c78c5083bda)

Result after patch:
```
+-------------+----+
| 012345 (abc | XX |
| defghij)    |    |
+-------------+----+
```
![fixed_tabulate_color_wrap](https://github.com/astanin/python-tabulate/assets/74280297/3660fe68-fce1-40e0-a0df-b5c682d81da4)

Fixes #307.