### PR TITLE
Bug fix for issue #318 | `intfmt`: error for strings which contain integer values

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1229,6 +1229,8 @@ def _format(val, valtype, floatfmt, intfmt, missingval="", has_invisible=True):
     if valtype is str:
         return f"{val}"
     elif valtype is int:
+        if isinstance(val, str):
+            intfmt = ""
         return format(val, intfmt)
     elif valtype is bytes:
         try:

--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1230,6 +1230,15 @@ def _format(val, valtype, floatfmt, intfmt, missingval="", has_invisible=True):
         return f"{val}"
     elif valtype is int:
         if isinstance(val, str):
+            val_striped = val.encode('unicode_escape').decode('utf-8')
+            colored = re.search(r'(\\[xX]+[0-9a-fA-F]+\[\d+[mM]+)([0-9.]+)(\\.*)$', val_striped)
+            if colored:
+                total_groups = len(colored.groups())
+                if total_groups == 3:
+                    digits = colored.group(2)
+                    if digits.isdigit():
+                        val_new = colored.group(1) + format(int(digits), intfmt) + colored.group(3)
+                        val = val_new.encode('utf-8').decode('unicode_escape')
             intfmt = ""
         return format(val, intfmt)
     elif valtype is bytes:

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1,4 +1,5 @@
 """Test output of the various forms of tabular data."""
+import pytest
 
 import tabulate as tabulate_module
 from common import assert_equal, raises, skip, check_warnings
@@ -2636,6 +2637,44 @@ def test_intfmt():
     result = tabulate([[10000], [10]], intfmt=",", tablefmt="plain")
     expected = "10,000\n    10"
     assert_equal(expected, result)
+
+
+def test_intfmt_with_string_as_integer():
+    "Output: integer format"
+    result = tabulate([[82642], ["1500"], [2463]], intfmt=",", tablefmt="plain")
+    expected = "82,642\n  1500\n 2,463"
+    assert_equal(expected, result)
+
+
+@pytest.mark.skip(reason="It detects all values as floats but there are strings and integers.")
+def test_intfmt_with_string_with_floats():
+    "Output: integer format"
+    result = tabulate([[82000.38], ["1500.47"], ["2463"], [92165]], intfmt=",", tablefmt="plain")
+    expected = "82000.4\n 1500.47\n 2463\n92,165"
+    assert_equal(expected, result)
+
+
+def test_intfmt_with_colors():
+    "Regression: Align ANSI-colored values as if they were colorless."
+    colortable = [
+        ("abcd", 42, "\x1b[31m42\x1b[0m"),
+        ("elfy", 1010, "\x1b[32m1010\x1b[0m"),
+    ]
+    colorheaders = ("test", "\x1b[34mtest\x1b[0m", "test")
+    formatted = tabulate(colortable, colorheaders, "grid", intfmt=",")
+    expected = "\n".join(
+        [
+            "+--------+--------+--------+",
+            "| test   |   \x1b[34mtest\x1b[0m |   test |",
+            "+========+========+========+",
+            "| abcd   |     42 |     \x1b[31m42\x1b[0m |",
+            "+--------+--------+--------+",
+            "| elfy   |  1,010 |   \x1b[32m1010\x1b[0m |",
+            "+--------+--------+--------+",
+        ]
+    )
+    print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")
+    assert_equal(expected, formatted)
 
 
 def test_empty_data_with_headers():

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1,5 +1,5 @@
 """Test output of the various forms of tabular data."""
-import pytest
+from pytest import mark
 
 import tabulate as tabulate_module
 from common import assert_equal, raises, skip, check_warnings
@@ -2646,7 +2646,7 @@ def test_intfmt_with_string_as_integer():
     assert_equal(expected, result)
 
 
-@pytest.mark.skip(reason="It detects all values as floats but there are strings and integers.")
+@mark.skip(reason="It detects all values as floats but there are strings and integers.")
 def test_intfmt_with_string_with_floats():
     "Output: integer format"
     result = tabulate([[82000.38], ["1500.47"], ["2463"], [92165]], intfmt=",", tablefmt="plain")

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -2657,20 +2657,20 @@ def test_intfmt_with_string_with_floats():
 def test_intfmt_with_colors():
     "Regression: Align ANSI-colored values as if they were colorless."
     colortable = [
-        ("abcd", 42, "\x1b[31m42\x1b[0m"),
-        ("elfy", 1010, "\x1b[32m1010\x1b[0m"),
+        ("\x1b[33mabc\x1b[0m", 42, "\x1b[31m42\x1b[0m"),
+        ("\x1b[35mdef\x1b[0m", 987654321, "\x1b[32m987654321\x1b[0m"),
     ]
     colorheaders = ("test", "\x1b[34mtest\x1b[0m", "test")
     formatted = tabulate(colortable, colorheaders, "grid", intfmt=",")
     expected = "\n".join(
         [
-            "+--------+--------+--------+",
-            "| test   |   \x1b[34mtest\x1b[0m |   test |",
-            "+========+========+========+",
-            "| abcd   |     42 |     \x1b[31m42\x1b[0m |",
-            "+--------+--------+--------+",
-            "| elfy   |  1,010 |   \x1b[32m1010\x1b[0m |",
-            "+--------+--------+--------+",
+            "+--------+-------------+-------------+",
+            "| test   |        \x1b[34mtest\x1b[0m |        test |",
+            "+========+=============+=============+",
+            "| \x1b[33mabc\x1b[0m    |          42 |          \x1b[31m42\x1b[0m |",
+            "+--------+-------------+-------------+",
+            "| \x1b[35mdef\x1b[0m    | 987,654,321 | \x1b[32m987,654,321\x1b[0m |",
+            "+--------+-------------+-------------+",
         ]
     )
     print(f"expected: {expected!r}\n\ngot:      {formatted!r}\n")


### PR DESCRIPTION
# Bug fix for issue #318 | `intfmt`: error for strings which contain integer values

## Description.

Resolved the problem with the `intfmt` argument.

Added tests for these changes.
Test results: `308 passed, 2 skipped in 1.10s`.