### PR TITLE
Fix argument parsing of the command line utility

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -2701,8 +2701,8 @@ def _main():
     try:
         opts, args = getopt.getopt(
             sys.argv[1:],
-            "h1o:s:F:A:f:",
-            ["help", "header", "output", "sep=", "float=", "int=", "align=", "format="],
+            "h1o:s:F:I:f:",
+            ["help", "header", "output=", "sep=", "float=", "int=", "colalign=", "format="],
         )
     except getopt.GetoptError as e:
         print(e)


### PR DESCRIPTION
The expected arguments in the command line utility do not match the help description. Furthermore, the long "--output" parameter was missing the following filename, and "--align" was later expected to be called "--colalign".