### PR TITLE
Add table format "colon_grid"

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1862,7 +1862,6 @@ def tabulate(
 
     >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]],
     ...                ["strings", "numbers"], "colon_grid"))
-
     +-----------+-----------+
     | strings   | numbers   |
     +:==========+:==========+
@@ -1873,8 +1872,7 @@ def tabulate(
 
     >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]],
     ...                ["strings", "numbers"], "colon_grid",
-    ...                colalign=["right, left"]))
-
+    ...                colalign=["right", "left"]))
     +-----------+-----------+
     | strings   | numbers   |
     +==========:+:==========+

--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -2199,6 +2199,9 @@ def tabulate(
         numalign = "decimal" if numalign == _DEFAULT_ALIGN else numalign
         stralign = "left" if stralign == _DEFAULT_ALIGN else stralign
 
+    # 'colon_grid' uses colons in the line beneath the header to represent a column's
+    # alignment instead of literally aligning the text differently. Hence,
+    # left alignment of the data in the text output is enforced.
     if tablefmt == "colon_grid":
         colglobalalign = "left"
         headersglobalalign = "left"
@@ -2285,6 +2288,8 @@ def tabulate(
         [width_fn(h) + min_padding for h in headers] if headers else [0] * len(cols)
     )
     aligns_copy = aligns.copy()
+    # Reset alignments in copy of alignments list to "left" for 'colon_grid' format,
+    # which enforces left alignment in the text output of the data.
     if tablefmt == "colon_grid":
         aligns_copy = ["left"] * len(cols)
     cols = [

--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1864,11 +1864,11 @@ def tabulate(
     ...                ["strings", "numbers"], "colon_grid"))
 
     +-----------+-----------+
-    | strings   |   numbers |
+    | strings   | numbers   |
     +:==========+:==========+
-    | spam      |   41.9999 |
+    | spam      | 41.9999   |
     +-----------+-----------+
-    | eggs      |  451      |
+    | eggs      | 451       |
     +-----------+-----------+
 
     >>> print(tabulate([["spam", 41.9999], ["eggs", "451.0"]],
@@ -1876,11 +1876,11 @@ def tabulate(
     ...                colalign=["right, left"]))
 
     +-----------+-----------+
-    | strings   |   numbers |
+    | strings   | numbers   |
     +==========:+:==========+
-    | spam      |   41.9999 |
+    | spam      | 41.9999   |
     +-----------+-----------+
-    | eggs      |  451      |
+    | eggs      | 451       |
     +-----------+-----------+
 
     "outline" is the same as the "grid" format but doesn't draw lines between rows:

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1413,7 +1413,9 @@ def test_fancy_grid_multiline_row_align():
     result = tabulate(table, tablefmt="fancy_grid", rowalign=[None, "center", "bottom"])
     assert_equal(expected, result)
 
+
 def test_colon_grid():
+    "Output: colon_grid with two columns aligned left and center"
     expected = "\n".join(
         [
             "+------+------+",
@@ -1424,6 +1426,82 @@ def test_colon_grid():
         ]
     )
     result = tabulate([[3, 4]], headers=("H1", "H2"), tablefmt="colon_grid", colalign=["right", "center"])
+    assert_equal(expected, result)
+
+
+def test_colon_grid_wide_characters():
+    "Output: colon_grid with wide chars in header"
+    try:
+        import wcwidth  # noqa
+    except ImportError:
+        skip("test_colon_grid_wide_characters is skipped")
+    headers = list(_test_table_headers)
+    headers[1] = "配列"
+    expected = "\n".join(
+        [
+            "+-----------+---------+",
+            "| strings   | 配列    |",
+            "+:==========+========:+",
+            "| spam      | 41.9999 |",
+            "+-----------+---------+",
+            "| eggs      | 451     |",
+            "+-----------+---------+",
+        ]
+    )
+    result = tabulate(_test_table, headers, tablefmt="colon_grid", colalign=["left", "right"])
+    assert_equal(expected, result)
+
+
+def test_colon_grid_headerless():
+    "Output: colon_grid without headers"
+    expected = "\n".join(
+        [
+            "+------+---------+",
+            "| spam | 41.9999 |",
+            "+------+---------+",
+            "| eggs | 451     |",
+            "+------+---------+",
+        ]
+    )
+    result = tabulate(_test_table, tablefmt="colon_grid")
+    assert_equal(expected, result)
+
+
+def test_colon_grid_multiline():
+    "Output: colon_grid with multiline cells"
+    table = [["Data\n5", "33\n3"]]
+    headers = ["H1\n1", "H2\n2"]
+    expected = "\n".join(
+        [
+            "+------+------+",
+            "| H1   | H2   |",
+            "| 1    | 2    |",
+            "+:=====+:=====+",
+            "| Data | 33   |",
+            "| 5    | 3    |",
+            "+------+------+",
+        ]
+    )
+    result = tabulate(table, headers, tablefmt="colon_grid")
+    assert_equal(expected, result)
+
+
+def test_colon_grid_with_empty_cells():
+    table = [["A", ""], ["", "B"]]
+    headers = ["H1", "H2"]
+    alignments = ["center", "right"]
+    expected = "\n".join(
+        [
+            "+------+------+",
+            "| H1   | H2   |",
+            "+:====:+=====:+",
+            "| A    |      |",
+            "+------+------+",
+            "|      | B    |",
+            "+------+------+",
+        ]
+    )
+    result = tabulate(table, headers, tablefmt="colon_grid", colalign=alignments)
     assert_equal(expected, result)
 
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1413,6 +1413,19 @@ def test_fancy_grid_multiline_row_align():
     result = tabulate(table, tablefmt="fancy_grid", rowalign=[None, "center", "bottom"])
     assert_equal(expected, result)
 
+def test_colon_grid():
+    expected = "\n".join(
+        [
+            "+------+------+",
+            "| H1   | H2   |",
+            "+=====:+:====:+",
+            "| 3    | 4    |",
+            "+------+------+",
+        ]
+    )
+    result = tabulate([[3, 4]], headers=("H1", "H2"), tablefmt="colon_grid", colalign=["right", "center"])
+    assert_equal(expected, result)
+
 
 def test_outline():
     "Output: outline with headers"


### PR DESCRIPTION
To close #332, this PR adds a new table format "colon_grid" which is the same as the "grid" format but adds colons to the line below the header to indicate a column's alignment. This requires forcing left alignment on the data in the text output of tabulate. 

With this format, tabulate can create Pandoc-compatible tables with alignments.

Existing grid format:
```md
+------------+------------+------------+
| Column 1   | Column 2   | Column 3   |
+============+============+============+
| 1          | a          | 1.23       |
+------------+------------+------------+
| 2          | b          | 12.3       |
+------------+------------+------------+
| 3          | c          | 123        |
+------------+------------+------------+
```

Grid format using existing alignment functionality:
```md
+------------+------------+------------+
|   Column 1 | Column 2   |   Column 3 |
+============+============+============+
|          1 | a          |       1.23 |
+------------+------------+------------+
|          2 | b          |      12.3  |
+------------+------------+------------+
|          3 | c          |     123    |
+------------+------------+------------+
```

Broken Pandoc rendering:

![345424732-71a74103-4560-4f52-bd3d-163171344a3d](https://github.com/user-attachments/assets/b187a7af-3f1a-48b9-b594-e722c1ebc8c2)

New colon_grid format:
```md
+------------+------------+------------+
| Column 1   | Column 2   | Column 3   |
+===========:+:===========+===========:+
| 1          | a          | 1.23       |
+------------+------------+------------+
| 2          | b          | 12.3       |
+------------+------------+------------+
| 3          | c          | 123        |
+------------+------------+------------+
```

Pandoc rendering of a colon_grid:

![345426116-064c2912-23cc-471d-ae7b-fa895a97ccfe](https://github.com/user-attachments/assets/79b82344-d4cd-4257-996a-7e84519ad834)
