### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/tabulate.yml
+++ b/.github/workflows/tabulate.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true

--- a/.github/workflows/tabulate.yml
+++ b/.github/workflows/tabulate.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
 requires-python = ">=3.9"

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -490,7 +490,7 @@ def test_preserve_line_breaks_with_maxcolwidths():
 
 def test_maxcolwidths_accepts_list_or_tuple():
     "Regression: maxcolwidths can accept a list or a tuple (github issue #214)"
-    table = [["lorem ipsum dolor sit amet"]*3]
+    table = [["lorem ipsum dolor sit amet"] * 3]
     expected = "\n".join(
         [
             "+-------------+----------+----------------------------+",

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@
 # for testing and it is disabled by default.
 
 [tox]
-envlist = lint, py{38, 39, 310, 311, 312}
+envlist = lint, py{38, 39, 310, 311, 312, 313}
 isolated_build = True
 
 [gh]
@@ -17,6 +17,7 @@ python =
     3.10: py310-extra
     3.11: py311-extra
     3.12: py312-extra
+    3.13: py313-extra
 
 [testenv]
 commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
@@ -105,6 +106,22 @@ deps =
 
 [testenv:py312-extra]
 basepython = python3.12
+setenv = PYTHONDEVMODE = 1
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
+deps =
+    pytest
+    numpy
+    pandas
+    wcwidth
+
+[testenv:py313]
+basepython = python3.13
+commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
+deps =
+    pytest
+
+[testenv:py313-extra]
+basepython = python3.13
 setenv = PYTHONDEVMODE = 1
 commands = pytest -v --doctest-modules --ignore benchmark.py {posargs}
 deps =


### PR DESCRIPTION
The final Python 3.13 release candidate is out now! :rocket:

The Release Manager has issued a [call to action](https://discuss.python.org/t/python-3-13-0rc2-3-12-6-3-11-10-3-10-15-3-9-20-and-3-8-20-are-now-available/63161?u=hugovk]):

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.13 compatibilities during this phase, and where necessary publish Python 3.13 wheels on PyPI to be ready for the final release of 3.13.0. Any binary wheels built against Python 3.13.0rc2 will work with future versions of Python 3.13. As always, report any issues to [the Python bug tracker](https://github.com/python/cpython/issues).