### PR TITLE
Correct README.md examples and outputs using doctest

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,6 +813,20 @@ data in the column is used to infer the type:
 
 ```
 
+The deduced type (eg. str, float) influences the rendering of any types
+that have alternative representations.  For example, since `Fraction` has
+methods `__str__` and `__float__` defined (and hence is convertible to a
+`float` and also has a `str` representation), the appropriate
+representation is selected for the column's deduced type.  In order to not
+lose precision accidentally, types having both an `__int__` and
+`__float__` represention will be considered a `float`.
+
+Therefore, if your table contains types convertible to int/float but you'd
+*prefer* they be represented as strings, or your strings *might* all look
+like numbers such as "1e23": either convert them to the desired
+representation before you `tabulate`, or ensure that the column always
+contains at least one other `str`.
+
 ### Text formatting
 
 By default, `tabulate` removes leading and trailing whitespace from text

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Earth    6371  5973.6
 Moon     1737    73.5
 Mars     3390   641.85
 -----  ------  -------------
+
 ```
 
 The following tabular data types are supported:
@@ -101,6 +102,7 @@ Sun         696000           1.9891e+09
 Earth         6371        5973.6
 Moon          1737          73.5
 Mars          3390         641.85
+
 ```
 
 If `headers="firstrow"`, then the first row of data is used:
@@ -112,6 +114,7 @@ Name      Age
 ------  -----
 Alice      24
 Bob        19
+
 ```
 
 If `headers="keys"`, then the keys of a dictionary/dataframe, or column
@@ -125,6 +128,7 @@ Name      Age
 ------  -----
 Alice      24
 Bob        19
+
 ```
 
 When data is a list of dictionaries, a dictionary can be passed as `headers`
@@ -137,6 +141,7 @@ Name      Age
 ------  -----
 Alice      24
 Bob        19
+
 ```
 
 ### Row Indices
@@ -154,6 +159,7 @@ or `showindex=False`. To add a custom row index column, pass
 0  F  24
 1  M  19
 -  -  --
+
 ```
 
 ### Table format
@@ -210,6 +216,7 @@ item      qty
 spam       42
 eggs      451
 bacon       0
+
 ```
 
 `simple` is the default format (the default may change in future
@@ -223,6 +230,7 @@ item      qty
 spam       42
 eggs      451
 bacon       0
+
 ```
 
 `github` follows the conventions of GitHub flavored Markdown. It
@@ -230,11 +238,12 @@ corresponds to the `pipe` format without alignment colons:
 
 ```pycon
 >>> print(tabulate(table, headers, tablefmt="github"))
-| item   | qty   |
+| item   |   qty |
 |--------|-------|
-| spam   | 42    |
-| eggs   | 451   |
-| bacon  | 0     |
+| spam   |    42 |
+| eggs   |   451 |
+| bacon  |     0 |
+
 ```
 
 `grid` is like tables formatted by Emacs'
@@ -252,6 +261,7 @@ corresponds to the `pipe` format without alignment colons:
 +--------+-------+
 | bacon  |     0 |
 +--------+-------+
+
 ```
 
 `simple_grid` draws a grid using single-line box-drawing characters:
@@ -333,6 +343,7 @@ corresponds to the `pipe` format without alignment colons:
 ├────────┼───────┤
 │ bacon  │     0 │
 ╘════════╧═══════╛
+
 ```
 
 `colon_grid` is similar to `grid` but uses colons only to define
@@ -437,6 +448,7 @@ similar the alignment specification of Pandoc `grid_tables`:
  spam   |    42
  eggs   |   451
  bacon  |     0
+
 ```
 
 `pretty` attempts to be close to the format emitted by the PrettyTables
@@ -451,6 +463,7 @@ library:
 | eggs  | 451 |
 | bacon |  0  |
 +-------+-----+
+
 ```
 
 `psql` is like tables formatted by Postgres' psql cli:
@@ -464,6 +477,7 @@ library:
 | eggs   |   451 |
 | bacon  |     0 |
 +--------+-------+
+
 ```
 
 `pipe` follows the conventions of [PHP Markdown
@@ -478,6 +492,7 @@ indicate column alignment:
 | spam   |    42 |
 | eggs   |   451 |
 | bacon  |     0 |
+
 ```
 
 `asciidoc` formats data like a simple table of the
@@ -488,11 +503,12 @@ format:
 >>> print(tabulate(table, headers, tablefmt="asciidoc"))
 [cols="8<,7>",options="header"]
 |====
-| item   |   qty
-| spam   |    42
-| eggs   |   451
-| bacon  |     0
+| item   |   qty 
+| spam   |    42 
+| eggs   |   451 
+| bacon  |     0 
 |====
+
 ```
 
 `orgtbl` follows the conventions of Emacs
@@ -506,6 +522,7 @@ in the minor orgtbl-mode. Hence its name:
 | spam   |    42 |
 | eggs   |   451 |
 | bacon  |     0 |
+
 ```
 
 `jira` follows the conventions of Atlassian Jira markup language:
@@ -516,6 +533,7 @@ in the minor orgtbl-mode. Hence its name:
 | spam   |    42 |
 | eggs   |   451 |
 | bacon  |     0 |
+
 ```
 
 `rst` formats data like a simple table of the
@@ -531,6 +549,7 @@ spam       42
 eggs      451
 bacon       0
 ======  =====
+
 ```
 
 `mediawiki` format produces a table markup used in
@@ -550,6 +569,7 @@ MediaWiki-based sites:
 |-
 | bacon  || style="text-align: right;"|     0
 |}
+
 ```
 
 `moinmoin` format produces a table markup used in
@@ -557,20 +577,22 @@ MediaWiki-based sites:
 
 ```pycon
 >>> print(tabulate(table, headers, tablefmt="moinmoin"))
-|| ''' item   ''' || ''' quantity   ''' ||
-||  spam    ||  41.999      ||
-||  eggs    ||  451         ||
-||  bacon   ||              ||
+|| ''' item   ''' ||<style="text-align: right;"> '''   qty ''' ||
+||  spam    ||<style="text-align: right;">     42  ||
+||  eggs    ||<style="text-align: right;">    451  ||
+||  bacon   ||<style="text-align: right;">      0  ||
+
 ```
 
 `youtrack` format produces a table markup used in Youtrack tickets:
 
 ```pycon
 >>> print(tabulate(table, headers, tablefmt="youtrack"))
-||  item    ||  quantity   ||
-|   spam    |  41.999      |
-|   eggs    |  451         |
-|   bacon   |              |
+||  item    ||    qty  ||
+|  spam    |     42  |
+|  eggs    |    451  |
+|  bacon   |      0  |
+
 ```
 
 `textile` format produces a table markup used in
@@ -582,6 +604,7 @@ MediaWiki-based sites:
 |<. spam    |>.    42 |
 |<. eggs    |>.   451 |
 |<. bacon   |>.     0 |
+
 ```
 
 `html` produces standard HTML markup as an html.escape'd str
@@ -592,13 +615,16 @@ and a .str property so that the raw HTML remains accessible.
 ```pycon
 >>> print(tabulate(table, headers, tablefmt="html"))
 <table>
-<tbody>
+<thead>
 <tr><th>item  </th><th style="text-align: right;">  qty</th></tr>
+</thead>
+<tbody>
 <tr><td>spam  </td><td style="text-align: right;">   42</td></tr>
 <tr><td>eggs  </td><td style="text-align: right;">  451</td></tr>
 <tr><td>bacon </td><td style="text-align: right;">    0</td></tr>
 </tbody>
 </table>
+
 ```
 
 `latex` format creates a `tabular` environment for LaTeX markup,
@@ -616,6 +642,7 @@ correspondents:
  bacon  &     0 \\
 \hline
 \end{tabular}
+
 ```
 
 `latex_raw` behaves like `latex` but does not escape LaTeX commands and
@@ -650,6 +677,7 @@ at a glance:
 12345
  1234.5
 ----------
+
 ```
 
 Compare this with a more common right alignment:
@@ -663,6 +691,7 @@ Compare this with a more common right alignment:
  12345
 1234.5
 ------
+
 ```
 
 For `tabulate`, anything which can be parsed as a number is a number.
@@ -671,7 +700,7 @@ comes in handy when reading a mixed table of text and numbers from a
 file:
 
 ```pycon
->>> import csv ; from StringIO import StringIO
+>>> import csv; from io import StringIO
 >>> table = list(csv.reader(StringIO("spam, 42\neggs, 451\n")))
 >>> table
 [['spam', ' 42'], ['eggs', ' 451']]
@@ -680,16 +709,18 @@ file:
 spam    42
 eggs   451
 ----  ----
+
 ```
 
 To disable this feature use `disable_numparse=True`.
 
 ```pycon
->>> print(tabulate.tabulate([["Ver1", "18.0"], ["Ver2","19.2"]], tablefmt="simple", disable_numparse=True))
+>>> print(tabulate([["Ver1", "18.0"], ["Ver2","19.2"]], tablefmt="simple", disable_numparse=True))
 ----  ----
 Ver1  18.0
 Ver2  19.2
 ----  ----
+
 ```
 
 ### Custom column alignment
@@ -704,6 +735,7 @@ Furthermore, you can define `colalign` for column-specific alignment as a list o
  1   2      3   4
 111  222  333  444
 ---  ---  ---  ---
+
 ```
 
 ### Custom header alignment
@@ -714,11 +746,11 @@ Headers' alignment can be defined separately from columns'. Like for columns, yo
 
 ```pycon
 >>> print(tabulate([[1,2,3,4,5,6],[111,222,333,444,555,666]], colglobalalign = 'center', colalign = ('left',), headers = ['h','e','a','d','e','r'], headersglobalalign = 'right', headersalign = ('same','same','left','global','center')))
-
 h     e   a      d   e     r
 ---  ---  ---  ---  ---  ---
 1     2    3    4    5    6
 111  222  333  444  555  666
+
 ```
 
 ### Number formatting
@@ -732,6 +764,7 @@ columns of decimal numbers. Use `floatfmt` named argument:
 pi  3.1416
 e   2.7183
 --  ------
+
 ```
 
 `floatfmt` argument can be a list or a tuple of format strings, one per
@@ -742,6 +775,7 @@ column, in which case every column may have different number formatting:
 ---  -----  -------
 0.1  0.123  0.12345
 ---  -----  -------
+
 ```
 
 `intfmt` works similarly for integers
@@ -751,6 +785,33 @@ column, in which case every column may have different number formatting:
     a   1,000
     b  90,000
     -  ------
+
+
+### Type Deduction and Missing Values
+
+When `tabulate` sees numerical data (with our without comma separators), it
+attempts to align the column on the decimal point.  However, if it observes
+non-numerical data in the column, it aligns it to the left by default.  If
+data is missing in a column (either None or empty values), the remaining
+data in the column is used to infer the type:
+
+```pycon
+>>> from fractions import Fraction
+>>> test_table = [
+...    [None, "1.23423515351", Fraction(1, 3)],
+...    [Fraction(56789, 1000000), 12345.1, b"abc"],
+...    ["", b"", None],
+...    [Fraction(10000, 3), None, ""],
+... ]
+>>> print(tabulate(test_table, floatfmt=",.5g", missingval="?"))
+------------  -----------  ---
+    ?              1.2342  1/3
+    0.056789  12,345       abc
+                           ?
+3,333.3            ?
+------------  -----------  ---
+
+```
 
 ### Text formatting
 
@@ -802,6 +863,7 @@ a multiline cell, and headers with a multiline cell:
 ```pycon
 >>> table = [["eggs",451],["more\nspam",42]]
 >>> headers = ["item\nname", "qty"]
+
 ```
 
 `plain` tables:
@@ -813,6 +875,7 @@ name
 eggs      451
 more       42
 spam
+
 ```
 
 `simple` tables:
@@ -825,6 +888,7 @@ name
 eggs      451
 more       42
 spam
+
 ```
 
 `grid` tables:
@@ -840,6 +904,7 @@ spam
 | more   |    42 |
 | spam   |       |
 +--------+-------+
+
 ```
 
 `fancy_grid` tables:
@@ -855,6 +920,7 @@ spam
 │ more   │    42 │
 │ spam   │       │
 ╘════════╧═══════╛
+
 ```
 
 `pipe` tables:
@@ -867,6 +933,7 @@ spam
 | eggs   |   451 |
 | more   |    42 |
 | spam   |       |
+
 ```
 
 `orgtbl` tables:
@@ -879,18 +946,19 @@ spam
 | eggs   |   451 |
 | more   |    42 |
 | spam   |       |
+
 ```
 
 `jira` tables:
 
 ```pycon
 >>> print(tabulate(table, headers, tablefmt="jira"))
-| item   |   qty |
-| name   |       |
-|:-------|------:|
+|| item   ||   qty ||
+|| name   ||       ||
 | eggs   |   451 |
 | more   |    42 |
 | spam   |       |
+
 ```
 
 `presto` tables:
@@ -903,6 +971,7 @@ spam
  eggs   |   451
  more   |    42
  spam   |
+
 ```
 
 `pretty` tables:
@@ -917,6 +986,7 @@ spam
 | more | 42  |
 | spam |     |
 +------+-----+
+
 ```
 
 `psql` tables:
@@ -931,6 +1001,7 @@ spam
 | more   |    42 |
 | spam   |       |
 +--------+-------+
+
 ```
 
 `rst` tables:
@@ -945,6 +1016,7 @@ eggs      451
 more       42
 spam
 ======  =====
+
 ```
 
 Multiline cells are not well-supported for the other table formats.
@@ -974,6 +1046,7 @@ the lines being wrapped would probably be significantly longer than this.
 | John Smith | Middle  |
 |            | Manager |
 +------------+---------+
+
 ```
 
 ### Adding Separating lines
@@ -1016,7 +1089,7 @@ hyperlinks is that column width will be based on the length of the URL _text_ ra
 itself (terminals would show this text). For example:
 
     >>> len('\x1b]8;;https://example.com\x1b\\example\x1b]8;;\x1b\\')  # display length is 7, showing 'example'
-    45
+    40
 
 
 Usage of the command line utility
@@ -1135,6 +1208,13 @@ tox -e lint
 
 See `tox.ini` file to learn how to use to test
 individual Python versions.
+
+To test the "doctest" examples and their outputs in `README.md`:
+
+```shell
+python3 -m pip install pytest-doctestplus[md]
+python3 -m doctest README.md
+```
 
 Contributors
 ------------


### PR DESCRIPTION
The 'README.md' contains numerous examples and expected outputs, but these don't appear to be regularly tested.

I added the formatting necessary to run "doctest" on the README.md and test the expected outputs.  Mostly this was just adding a doctest-terminating blank line after the expected outputs.  However, several of the tests showed some differences in output.

Check that these are indeed now correct, and then this should be ready to merge.

I also added instructions on how to run doctest on the `README.md`.