### PR TITLE
Fix handling "True"/"False" bool str and None

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1641,13 +1641,7 @@ def _wrap_text_to_colwidths(list_of_lists, colwidths, numparses=True):
 
             if width is not None:
                 wrapper = _CustomTextWrap(width=width)
-                # Cast based on our internal type handling. Any future custom
-                # formatting of types (such as datetimes) may need to be more
-                # explicit than just `str` of the object. Also doesn't work for
-                # custom floatfmt/intfmt, nor with any missing/blank cells.
-                casted_cell = (
-                    str(cell) if _isnumber(cell) else _type(cell, numparse)(cell)
-                )
+                casted_cell = str(cell)
                 wrapped = [
                     "\n".join(wrapper.wrap(line))
                     for line in casted_cell.splitlines()

--- a/test/test_textwrapper.py
+++ b/test/test_textwrapper.py
@@ -220,3 +220,27 @@ def test_wrap_datetime():
     ]
     expected = "\n".join(expected)
     assert_equal(expected, result)
+
+
+def test_wrap_optional_bool_strs():
+    """TextWrapper: Show that str bools and None can be wrapped without crashing"""
+    data = [
+        ["First Entry", "True"],
+        ["Second Entry", None],
+    ]
+    headers = ["Title", "When"]
+    result = tabulate(data, headers=headers, tablefmt="grid", maxcolwidths=[7, 5])
+
+    expected = [
+        "+---------+--------+",
+        "| Title   | When   |",
+        "+=========+========+",
+        "| First   | True   |",
+        "| Entry   |        |",
+        "+---------+--------+",
+        "| Second  | None   |",
+        "| Entry   |        |",
+        "+---------+--------+",
+    ]
+    expected = "\n".join(expected)
+    assert_equal(expected, result)


### PR DESCRIPTION
calling `_type` is incorrect here; the subsequent lines need a `str`. Also you can't reconstruct `None` with `type(None)(None)` anyway. This regressed in e8e3091d46966f462735f227d5ef4effdfaa0582

Fixes #305