### PR TITLE
Fix multiline support for github format

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -737,6 +737,7 @@ multiline_formats = {
     "pretty": "pretty",
     "psql": "psql",
     "rst": "rst",
+    "github": "github",
     "outline": "outline",
     "simple_outline": "simple_outline",
     "rounded_outline": "rounded_outline",

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -509,6 +509,23 @@ def test_github():
     assert_equal(expected, result)
 
 
+def test_github_multiline():
+    "Output: github with multiline cells with headers"
+    table = [[2, "foo\nbar"]]
+    headers = ("more\nspam eggs", "more spam\n& eggs")
+    expected = "\n".join(
+        [
+            "|        more | more spam   |",
+            "|   spam eggs | & eggs      |",
+            "|-------------|-------------|",
+            "|           2 | foo         |",
+            "|             | bar         |",
+        ]
+    )
+    result = tabulate(table, headers, tablefmt="github")
+    assert_equal(expected, result)
+
+
 def test_grid():
     "Output: grid with headers"
     expected = "\n".join(


### PR DESCRIPTION
## Issue (https://github.com/astanin/python-tabulate/issues/355#issuecomment-2754367738)
In the `tabulate` library, the `github` format did not properly handle multiline text.  
If you passed tabulate data cells containing multiline text and used the `maxcolwidths` parameter to truncate text, the result was incorrect because the `github` format was not included in the list of formats that support multiline text processing.

## Solution
The issue was that the `github` format was not added to the `multiline_formats` dictionary, which defines the formats that support multiline text.  
The solution was simple: just add `"github": "github"` to this dictionary.

After our fix, the `github` format now correctly processes multiline text, just like other supported formats such as `fancy_outline`.