### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,16 @@
 [build-system]
-requires = ["setuptools>=61.2.0", "setuptools_scm[toml]>=3.4.3"]
+requires = ["setuptools>=77.0.3", "setuptools_scm[toml]>=3.4.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "tabulate"
 authors = [{name = "Sergey Astanin", email = "s.astanin@gmail.com"}]
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 description = "Pretty-print tabular data"
 readme = "README.md"
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Declare licenses using only these two fields, as per PEP 639:
* `license`:       SPDX license expression consisting of one or more license identifiers
* `license-files`: list of license file glob patterns

Supported by setuptools ≥ 77.0, or perhaps setuptools ≥ 77.0.3 which irons out some bugs:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

Also addresses this [Repo-Review suggestion](https://learn.scientific-python.org/development/guides/repo-review/?repo=astanin%2Fpython-tabulate&ref=master&refType=branch):
> [`PP005`](https://learn.scientific-python.org/development/guides/packaging-simple#PP005): Using SPDX project.license should not use deprecated trove classifiers