### PR TITLE
Unnecessary `list` call

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -723,7 +723,7 @@ _table_formats = {
 }
 
 
-tabulate_formats = list(sorted(_table_formats.keys()))
+tabulate_formats = sorted(_table_formats.keys())
 
 # The table formats for which multiline cells will be folded into subsequent
 # table rows. The key is the original format specified at the API. The value is


### PR DESCRIPTION
The `sorted()` function returns a list:
https://docs.python.org/3/library/functions.html#sorted

Requires https://github.com/astanin/python-tabulate/pull/373.