### PR TITLE
Do not call `getattr` with a constant value

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1523,7 +1523,7 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
         elif (
             headers == "keys"
             and hasattr(tabular_data, "dtype")
-            and getattr(tabular_data.dtype, "names")
+            and tabular_data.dtype.names
         ):
             # numpy record array
             headers = tabular_data.dtype.names


### PR DESCRIPTION
It is not any safer than normal property access.

It feels like the intent might have been `hasattr()` instead of `getattr()`, but the initial commit e2086c3 appears to :
- assume any attribute `dtype` is of type `numpy.dtype`,
- test whether `numpy.dtype.names` is a list of fields names or `None`.

https://numpy.org/doc/stable/reference/generated/numpy.dtype.names.html

Requires https://github.com/astanin/python-tabulate/pull/373.