### PR TITLE
Fix IndexError with maxheadercolwidths on empty tables

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -2262,18 +2262,24 @@ def tabulate(
         )
 
     if maxheadercolwidths is not None:
-        num_cols = len(list_of_lists[0])
-        if isinstance(maxheadercolwidths, int):  # Expand scalar for all columns
-            maxheadercolwidths = _expand_iterable(
-                maxheadercolwidths, num_cols, maxheadercolwidths
-            )
-        else:  # Ignore col width for any 'trailing' columns
-            maxheadercolwidths = _expand_iterable(maxheadercolwidths, num_cols, None)
+        if len(list_of_lists):
+            num_cols = len(list_of_lists[0])
+        elif len(headers):
+            num_cols = len(headers)
+        else:
+            num_cols = 0
+        if num_cols:
+            if isinstance(maxheadercolwidths, int):  # Expand scalar for all columns
+                maxheadercolwidths = _expand_iterable(
+                    maxheadercolwidths, num_cols, maxheadercolwidths
+                )
+            else:  # Ignore col width for any 'trailing' columns
+                maxheadercolwidths = _expand_iterable(maxheadercolwidths, num_cols, None)
 
-        numparses = _expand_numparse(disable_numparse, num_cols)
-        headers = _wrap_text_to_colwidths(
-            [headers], maxheadercolwidths, numparses=numparses, break_long_words=break_long_words, break_on_hyphens=break_on_hyphens
-        )[0]
+            numparses = _expand_numparse(disable_numparse, num_cols)
+            headers = _wrap_text_to_colwidths(
+                [headers], maxheadercolwidths, numparses=numparses, break_long_words=break_long_words, break_on_hyphens=break_on_hyphens
+            )[0]
 
     # empty values in the first column of RST tables should be escaped (issue #82)
     # "" should be escaped as "\\ " or ".."


### PR DESCRIPTION
When `maxheadercolwidths` is passed and the table has no data rows, `tabulate()` raises an `IndexError` because it tries to access `list_of_lists[0]` to determine the column count on an empty list.

```python
>>> tabulate([], headers=["one", "two", "three"], maxheadercolwidths=5)
IndexError: list index out of range
```

This fix checks whether `list_of_lists` is empty and falls back to `len(headers)` for the column count, which is the same pattern already used in the `maxcolwidths` handling a few lines above.

```python
>>> tabulate([], headers=["one", "two", "three"], maxheadercolwidths=5)
'one    two    three\n-----  -----  -------'
```

Fixes #365
