### PR TITLE
Handle ValueError in _format when float conversion fails for bool-like strings

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1352,12 +1352,18 @@ def _format(val, valtype, floatfmt, intfmt, missingval="", has_invisible=True):
         is_a_colored_number = has_invisible and isinstance(val, (str, bytes))
         if is_a_colored_number:
             raw_val = _strip_ansi(val)
-            formatted_val = format(float(raw_val), floatfmt)
+            try:
+                formatted_val = format(float(raw_val), floatfmt)
+            except (ValueError, TypeError):
+                return f"{val}"
             return val.replace(raw_val, formatted_val)
         else:
             if isinstance(val, str) and "," in val:
                 val = val.replace(",", "")  # handle thousands-separators
-            return format(float(val), floatfmt)
+            try:
+                return format(float(val), floatfmt)
+            except (ValueError, TypeError):
+                return f"{val}"
     else:
         return f"{val}"
 


### PR DESCRIPTION
Fixes #209.

When a column contains both bool-like strings (`'True'`/`'False'`) and numeric strings (e.g. `'1.'`), the column type is detected as `float`. Then `_format` calls `float('False')` which raises `ValueError`.

The fix catches `ValueError`/`TypeError` in the float formatting branch of `_format` and falls back to string formatting for unconvertible values.

Before:
```python
>>> tabulate([['False'], ['1.']])
ValueError: could not convert string to float: 'False'
```

After:
```python
>>> tabulate([['False'], ['1.']])
'-----\nFalse\n    1\n-----'
```
