### PR TITLE
Proper initialization for `__version__`

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -8,7 +8,10 @@ from importlib.metadata import (
 try:
     __version__ = _version("tabulate")
 except _PackageNotFoundError:
-    __version__ = "unknown"
+    try:
+        from .version import version as __version__  # noqa: F401
+    except ImportError:
+        __version__ = "unknown"
 
 import warnings
 from collections import namedtuple
@@ -35,11 +38,6 @@ def _is_file(f):
 
 
 __all__ = ["tabulate", "tabulate_formats", "simple_separated_format"]
-try:
-    from .version import version as __version__  # noqa: F401
-except ImportError:
-    pass  # running __init__.py as a script, AppVeyor pytests
-
 
 # minimum extra space in headers
 MIN_PADDING = 2


### PR DESCRIPTION
Also, AppVeyor is not used any more, is it?

I believe this is the proper way to find the version:
1. Try with [importlib.metadata.version](https://docs.python.org/3/library/importlib.metadata.html#importlib.metadata.version):
   > The `version()` function is the quickest way to get a [Distribution Package](https://packaging.python.org/en/latest/glossary/#term-Distribution-Package)’s version number, as a string:
2. Fall back to `version.py` if running from outside a package, as a script.