### PR TITLE
Use `is` to compare types

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -126,12 +126,10 @@ def _is_separating_line_value(value):
 
 def _is_separating_line(row):
     row_type = type(row)
-    is_sl = (row_type == list or row_type == str) and (
+    return (row_type is list or row_type is str) and (
         (len(row) >= 1 and _is_separating_line_value(row[0]))
         or (len(row) >= 2 and _is_separating_line_value(row[1]))
     )
-
-    return is_sl
 
 
 def _pipe_segment_with_colons(align, colwidth):


### PR DESCRIPTION
This is consistent with other similar checks in the code base:
https://github.com/astanin/python-tabulate/blob/71282a68dc3a5ab1e42449dd196cb97b0d5a88c9/tabulate/__init__.py#L123-L124

I wonder whether [`isinstance()`](https://docs.python.org/3/library/functions.html#isinstance) would be more appropriate. I mean, subclasses of `list` and `str` would also fit here.