### PR TITLE
fix: honor fancy_grid maxcolwidths including cell padding

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -2256,6 +2256,14 @@ def tabulate(
         else:  # Ignore col width for any 'trailing' columns
             maxcolwidths = _expand_iterable(maxcolwidths, num_cols, None)
 
+        # For fancy_grid, reserve left/right cell padding space before wrapping so
+        # maxcolwidths caps the rendered column width (issue #354).
+        if tablefmt == "fancy_grid":
+            wrap_padding = _table_formats["fancy_grid"].padding * 2
+            maxcolwidths = [
+                None if w is None else max(1, w - wrap_padding) for w in maxcolwidths
+            ]
+
         numparses = _expand_numparse(disable_numparse, num_cols)
         list_of_lists = _wrap_text_to_colwidths(
             list_of_lists,

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -223,6 +223,29 @@ def test_plain_maxheadercolwidths_autowraps():
     assert_equal(expected, result)
 
 
+def test_fancy_grid_maxcolwidth_includes_padding():
+    "Output: fancy_grid maxcolwidths caps rendered width including padding"
+    table = [["The files were concatenated and archived for posterity."]]
+    expected = "\n".join(
+        [
+            "╒══════════╕",
+            "│ col      │",
+            "╞══════════╡",
+            "│ The      │",
+            "│ files    │",
+            "│ were con │",
+            "│ catenate │",
+            "│ d and    │",
+            "│ archived │",
+            "│ for post │",
+            "│ erity.   │",
+            "╘══════════╛",
+        ]
+    )
+    result = tabulate(table, headers=["col"], tablefmt="fancy_grid", maxcolwidths=[10])
+    assert_equal(expected, result)
+
+
 def test_simple():
     "Output: simple with headers"
     expected = "\n".join(


### PR DESCRIPTION
## Summary
- adjust `maxcolwidths` wrapping for `fancy_grid` to reserve the format's left/right cell padding before wrapping
- keep behavior for other table formats unchanged to avoid regressions in existing output expectations
- add regression coverage for issue #354 to verify `fancy_grid` rendered column width is capped by `maxcolwidths`

## Testing
- `PYTHONPATH=. pytest -q test/test_output.py -k 'maxcolwidth or fancy_grid_maxcolwidth_includes_padding'`

## Related
Fixes #354
