### PR TITLE
fix: Correctly pass numparse to _type call in _wrap_text_to_colwidths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1274,4 +1274,4 @@ Keyacom, Andrew Coffey, Arpit Jain, Israel Roldan, ilya112358,
 Dan Nicholson, Frederik Scheerer, cdar07 (cdar), Racerroar888,
 Perry Kundert, Hnasar, Jun Koo, Jo2234, Bjorn Olsen, George Schizas,
 Kadir Can Ozden, Jeff Quast, Mayukha Vadari, Rebecca Jean Herman,
-Ján Jančár (J08nY).
+Ján Jančár (J08nY), Bradley Kirton.

--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1653,7 +1653,7 @@ def _wrap_text_to_colwidths(
                     else (
                         str(cell)
                         if cell == "" or _isnumber(cell)
-                        else str(_type(cell, numparse)(cell))
+                        else str(_type(cell, numparse=numparse)(cell))
                     )
                 )
                 wrapped = [

--- a/test/test_internal.py
+++ b/test/test_internal.py
@@ -1,5 +1,7 @@
 """Tests of the internal tabulate functions."""
 
+import pytest
+
 import tabulate as T
 
 from common import assert_equal, cols_to_pipe_str, rows_to_pipe_table_str, skip
@@ -207,6 +209,31 @@ def test_wrap_text_to_numbers():
     ]
 
     result = T._wrap_text_to_colwidths(rows, widths, numparses=[True, True, False])
+    assert_equal(expected, result)
+
+
+def test_wrap_text_to_colwidths_numparses_disabled():
+    "Internal: Test _wrap_text_to_colwidths to show it will correctly pass along the numparses input"
+    rows = [
+        ["a", "b"],
+        [
+            "1,000,000",
+            "1,000,000.00",
+        ],
+    ]
+    widths = [20, 20]
+    numparses = [True, True]
+
+    # This will raise because _type identifies 1,000,000 as int and 1,000,000.00 as float.
+    # See _isnumber_with_thousands_separator
+    with pytest.raises(ValueError):
+        T._wrap_text_to_colwidths(rows, widths, numparses=numparses)
+
+    # Switch off number parsing
+    numparses = [False, False]
+    expected = [["a", "b"], ["1,000,000", "1,000,000.00"]]
+
+    result = T._wrap_text_to_colwidths(rows, widths, numparses=numparses)
     assert_equal(expected, result)
 
 


### PR DESCRIPTION
Hi :wave: I noticed the `_type` call  in `_wrap_text_to_colwidths` was passing `numparse` as a positional argument which would set the `has_invisible` input rather than the `numparse` input.

I created this PR which now passes `numparse` as a keyword argument. One potential issue is the behavior of `has_invisible` was driven by whatever `numparse` was. In this implementation it defaults to `True` which is the argument default.

I have also included a test.