### PR TITLE
Enforce ruff/flake8-bugbear rules (B)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ line-length = 99
 exclude = ["tabulate/_version.py"]
 
 [tool.ruff.lint]
-extend-select = ["W", "C4", "ISC", "I", "C90", "UP"]
-ignore = ["E721", "C901"]
+extend-select = ["W", "B", "C4", "ISC", "I", "C90", "UP"]
+ignore = ["B905", "E721", "C901"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 22

--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -1478,8 +1478,8 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
             keys = tabular_data.keys()
             try:
                 rows = list(izip_longest(*tabular_data.values()))  # columns have to be transposed
-            except TypeError:  # not iterable
-                raise TypeError(err_msg)
+            except TypeError as e:  # not iterable
+                raise TypeError(err_msg) from e
 
         elif hasattr(tabular_data, "index"):
             # values is a property, has .index => it's likely a pandas.DataFrame (pandas 0.11.0)
@@ -1502,8 +1502,8 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
     else:  # it's a usual iterable of iterables, or a NumPy array, or an iterable of dataclasses
         try:
             rows = list(tabular_data)
-        except TypeError:  # not iterable
-            raise TypeError(err_msg)
+        except TypeError as e:  # not iterable
+            raise TypeError(err_msg) from e
 
         if headers == "keys" and not rows:
             # an empty table (issue #81)

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -97,7 +97,7 @@ def test_iter_of_iters_with_headers():
         def mk_iter():
             yield from range(3)
 
-        for r in range(3):
+        for _ in range(3):
             yield mk_iter()
 
     def mk_headers():
@@ -357,7 +357,7 @@ def test_numpy_array_as_headers():
         expected = "foo    bar"
         assert_equal(expected, result)
     except ImportError:
-        raise skip("")
+        raise skip("") from None
 
 
 def test_boolean_columns():
@@ -477,7 +477,7 @@ def test_numpy_array_as_showindex():
     try:
         import numpy as np
     except ImportError:
-        raise skip("")
+        raise skip("") from None
 
     table = [["a"], ["b"], ["c"]]
     # np.array([...]) == "default" returns an element-wise boolean array whose
@@ -548,7 +548,7 @@ def test_numpy_int64_as_integer():
         )
         assert_equal(expected, result)
     except ImportError:
-        raise skip("")
+        raise skip("") from None
 
 
 def test_empty_table_with_colalign():


### PR DESCRIPTION
This is recommended by [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=astanin%2Fpython-tabulate&ref=HEAD&refType=branch):
> [RF101](https://learn.scientific-python.org/development/guides/style#RF101): Bugbear must be selected

I have decided to ignore this rules for now:
* [zip-without-explicit-strict (B905)](https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/#zip-without-explicit-strict-b905)