### PR TITLE
Fix maxcolwidths width inflation with firstrow headers in grid formats

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -2388,6 +2388,22 @@ def tabulate(
             elif align != "global":
                 aligns[idx] = align
     minwidths = [width_fn(h) + min_padding for h in headers] if headers else [0] * len(cols)
+    if headers and maxcolwidths is not None:
+        tablefmt_obj = (
+            tablefmt
+            if isinstance(tablefmt, TableFormat)
+            else _table_formats.get(tablefmt, _table_formats["simple"])
+        )
+        if tablefmt_obj.padding > 0:
+            # If a max content width is set for a padded format (for example,
+            # grid/fancy_grid), don't add the default extra header spacing
+            # beyond that width. Keep at least the visible header width so long
+            # headers still render correctly unless explicitly wrapped via
+            # maxheadercolwidths.
+            minwidths = [
+                min(minw, max(width_fn(h), maxw)) if maxw is not None else minw
+                for h, minw, maxw in zip(headers, minwidths, maxcolwidths)
+            ]
     aligns_copy = aligns.copy()
     # Reset alignments in copy of alignments list to "left" for 'colon_grid' format,
     # which enforces left alignment in the text output of the data.

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -531,6 +531,22 @@ def test_exception_on_empty_data_with_maxcolwidths():
     assert_equal(result, "")
 
 
+def test_maxcolwidths_respects_requested_width_with_firstrow_header():
+    "Regression: avoid extra width inflation from firstrow headers (github issue #354)"
+    table = [["foo"], ["bar"]]
+    expected = "\n".join(
+        [
+            "+-----+",
+            "| foo |",
+            "+=====+",
+            "| bar |",
+            "+-----+",
+        ]
+    )
+    result = tabulate(table, headers="firstrow", tablefmt="grid", maxcolwidths=3)
+    assert_equal(expected, result)
+
+
 def test_numpy_int64_as_integer():
     "Regression: format numpy.int64 as integer (github issue #18)"
     try:


### PR DESCRIPTION
## Summary
- avoid inflating first-row header column widths beyond `maxcolwidths` for padded table formats (for example `grid`/`fancy_grid`)
- keep existing behavior for non-padded formats (such as `plain`), where the extra inter-column spacing is still expected
- add a regression test for issue #354 using the maintainer-provided minimal repro (`headers="firstrow"`, `tablefmt="grid"`, `maxcolwidths=3`)

## Testing
- `python -m pytest test/test_regression.py -k "maxcolwidths or firstrow_header"`
- `python -m pytest test/test_output.py -k "maxcolwidth_single_value or maxcolwidth_pad_tailing_widths or maxcolwidth_honor_disable_parsenum"`

## Related
Fixes #354
