### PR TITLE
fix: accept tuples (and any sequence) in _expand_iterable, not just lists

### DIFF
--- a/tabulate/__init__.py
+++ b/tabulate/__init__.py
@@ -2488,7 +2488,7 @@ def _expand_iterable(original, num_desired, default):
     length `num_desired` completely populated with `default will be returned
     """
     if isinstance(original, Iterable) and not isinstance(original, str):
-        return original + [default] * (num_desired - len(original))
+        return list(original) + [default] * (num_desired - len(original))
     else:
         return [default] * num_desired
 


### PR DESCRIPTION
Fixes #434

## Problem

`tabulate()` raises `TypeError` when sequence-valued parameters like `rowalign` or `maxheadercolwidths` are passed as tuples instead of lists:

```python
from tabulate import tabulate

tabulate([[1, 2], [3, 4]], rowalign=("top", "bottom"))
# TypeError: can only concatenate tuple (not "list") to tuple

tabulate([[1, 2], [3, 4]], rowalign=["top", "bottom"])  # works
```

All other sequence-valued parameters (`colalign`, `floatfmt`, `maxcolwidths`, etc.) accept tuples, so this is an inconsistency.

## Root cause

`_expand_iterable` does `original + [default] * n`. When `original` is a tuple, `tuple + list` raises `TypeError`.

## Fix

Coerce `original` to a `list` before concatenation:

```python
# before
return original + [default] * (num_desired - len(original))
# after
return list(original) + [default] * (num_desired - len(original))
```